### PR TITLE
add claude-opus-4-6 handling

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hyperbrowser/sdk",
-  "version": "0.82.2",
+  "version": "0.82.3",
   "description": "Node SDK for Hyperbrowser API",
   "author": "",
   "main": "dist/index.js",

--- a/src/types/constants.ts
+++ b/src/types/constants.ts
@@ -49,6 +49,7 @@ export type BrowserUseLlm =
 
 export type ClaudeComputerUseLlm =
   | "claude-opus-4-5"
+  | "claude-opus-4-6"
   | "claude-haiku-4-5-20251001"
   | "claude-sonnet-4-5"
   | "claude-sonnet-4-20250514"


### PR DESCRIPTION
## Summary
- add support for `claude-opus-4-6` in the SDK `ClaudeComputerUseLlm` union type
- bump SDK version from `0.82.2` to `0.82.3`
