### PR TITLE
Add post-quantum key agreement disable option to session config

### DIFF
--- a/src/types/session.ts
+++ b/src/types/session.ts
@@ -44,6 +44,7 @@ export interface SessionLaunchState {
   disablePasswordManager?: boolean;
   enableAlwaysOpenPdfExternally?: boolean;
   appendTimestampToDownloads?: boolean;
+  disablePostQuantumKeyAgreement?: boolean;
 }
 
 export interface Session {
@@ -142,6 +143,7 @@ export interface CreateSessionParams {
   showScrollbars?: boolean;
   liveViewTtlSeconds?: number;
   replaceNativeElements?: boolean;
+  disablePostQuantumKeyAgreement?: boolean;
 }
 
 export interface SessionRecording {


### PR DESCRIPTION
## Summary
Added support for disabling post-quantum key agreement in session configuration by introducing a new optional `disablePostQuantumKeyAgreement` parameter.