### PR TITLE
Add support for claude-sonnet-4-6 model

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hyperbrowser/sdk",
-  "version": "0.83.2",
+  "version": "0.83.3",
   "description": "Node SDK for Hyperbrowser API",
   "author": "",
   "main": "dist/index.js",

--- a/src/types/constants.ts
+++ b/src/types/constants.ts
@@ -40,6 +40,7 @@ export type BrowserUseLlm =
   | "gpt-5"
   | "gpt-5-mini"
   | "claude-sonnet-4-5"
+  | "claude-sonnet-4-6"
   | "claude-sonnet-4-20250514"
   | "claude-3-7-sonnet-20250219"
   | "claude-3-5-sonnet-20241022"
@@ -52,6 +53,7 @@ export type ClaudeComputerUseLlm =
   | "claude-opus-4-6"
   | "claude-haiku-4-5-20251001"
   | "claude-sonnet-4-5"
+  | "claude-sonnet-4-6"
   | "claude-sonnet-4-20250514"
   | "claude-3-7-sonnet-20250219";
 
@@ -68,6 +70,7 @@ export type HyperAgentLlm =
   | "gpt-4.1-mini"
   | "gpt-4.1-nano"
   | "claude-sonnet-4-5"
+  | "claude-sonnet-4-6"
   | "gemini-2.5-flash"
   | "gemini-3-flash-preview";
 


### PR DESCRIPTION
## Summary
This PR adds support for the new `claude-sonnet-4-6` Claude model across multiple LLM type definitions in the SDK.

## Key Changes
- Added `claude-sonnet-4-6` to the `BrowserUseLlm` type union
- Added `claude-sonnet-4-6` to the `ClaudeComputerUseLlm` type union
- Added `claude-sonnet-4-6` to the `HyperAgentLlm` type union
- Bumped package version from 0.83.2 to 0.83.3