### PR TITLE
add workflow yml file

### DIFF
--- a/.github/workflows/publish-npm.yml
+++ b/.github/workflows/publish-npm.yml
@@ -1,0 +1,67 @@
+name: Publish to npm
+
+on:
+  release:
+    types: [published]
+
+concurrency:
+  group: npm-publish-${{ github.event.release.tag_name }}
+  cancel-in-progress: false
+
+permissions:
+  contents: read
+  id-token: write
+
+jobs:
+  publish:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v5
+
+      - name: Set up Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: 22
+          registry-url: https://registry.npmjs.org
+          cache: yarn
+
+      - name: Set up Yarn
+        run: |
+          corepack enable
+          corepack prepare yarn@1.22.22 --activate
+
+      - name: Verify release tag matches package.json version
+        shell: bash
+        run: |
+          PKG_VERSION=$(node -p "require('./package.json').version")
+          TAG_VERSION="${GITHUB_REF_NAME#v}"
+
+          echo "package.json: $PKG_VERSION"
+          echo "release tag:   $TAG_VERSION"
+
+          test "$PKG_VERSION" = "$TAG_VERSION"
+
+      - name: Check if version already exists on npm
+        shell: bash
+        run: |
+          PACKAGE_NAME=$(node -p "require('./package.json').name")
+          PACKAGE_VERSION=$(node -p "require('./package.json').version")
+
+          if npm view "${PACKAGE_NAME}@${PACKAGE_VERSION}" version >/dev/null 2>&1; then
+            echo "Version already published: ${PACKAGE_NAME}@${PACKAGE_VERSION}"
+            exit 1
+          fi
+
+      - name: Install dependencies
+        run: yarn install --frozen-lockfile
+
+      - name: Build package
+        run: yarn build
+
+      - name: Inspect publish contents
+        run: npm pack --dry-run
+
+      - name: Publish package
+        run: npm publish --access public

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hyperbrowser/sdk",
-  "version": "0.88.0",
+  "version": "0.88.1",
   "description": "Node SDK for Hyperbrowser API",
   "author": "",
   "main": "dist/index.js",


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Introduces automated publishing to npm on GitHub Releases, which can impact release integrity if tags/versions or publish permissions are misconfigured. Guardrails are added (tag/version match and existing-version check), but the workflow still changes production release behavior.
> 
> **Overview**
> Adds a new GitHub Actions workflow (`publish-npm.yml`) that **automatically builds and publishes the package to npm** when a GitHub Release is published, using release-tag concurrency and OIDC `id-token` permissions.
> 
> The workflow enforces **version safety checks** by requiring the release tag (minus `v`) to match `package.json` and failing if that version already exists on npm, then runs `yarn build`, `npm pack --dry-run`, and `npm publish --access public`.
> 
> Bumps `package.json` version from `0.88.0` to `0.88.1`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 158723a79be11573e1b738f0a02d4e8de46d0b50. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->