### PR TITLE
add vcpu, memory, disk config

### DIFF
--- a/README.md
+++ b/README.md
@@ -159,11 +159,16 @@ const main = async () => {
   const sandbox = await client.sandboxes.create({
     imageName: "ubuntu-24-node",
     region: "us-west",
+    cpu: 4,
+    memory: 4096,
+    disk: 8192,
   });
 
   // Provide exactly one launch source:
   // snapshotName or imageName.
   // snapshotId requires snapshotName and imageId requires imageName.
+  // cpu, memory, and disk are only available for image launches.
+  // memory and disk are specified in MiB.
 
   const version = await sandbox.exec("node -v");
   console.log(version.stdout.trim());
@@ -240,6 +245,9 @@ Create a sandbox with pre-exposed ports:
 ```typescript
 const sandbox = await client.sandboxes.create({
   imageName: "node",
+  cpu: 2,
+  memory: 2048,
+  disk: 8192,
   exposedPorts: [{ port: 3000, auth: true }],
 });
 

--- a/README.md
+++ b/README.md
@@ -160,15 +160,14 @@ const main = async () => {
     imageName: "ubuntu-24-node",
     region: "us-west",
     cpu: 4,
-    memory: 4096,
-    disk: 8192,
+    memoryMiB: 4096,
+    diskMiB: 8192,
   });
 
   // Provide exactly one launch source:
   // snapshotName or imageName.
   // snapshotId requires snapshotName and imageId requires imageName.
-  // cpu, memory, and disk are only available for image launches.
-  // memory and disk are specified in MiB.
+  // cpu, memoryMiB, and diskMiB are only available for image launches.
 
   const version = await sandbox.exec("node -v");
   console.log(version.stdout.trim());
@@ -246,8 +245,8 @@ Create a sandbox with pre-exposed ports:
 const sandbox = await client.sandboxes.create({
   imageName: "node",
   cpu: 2,
-  memory: 2048,
-  disk: 8192,
+  memoryMiB: 2048,
+  diskMiB: 8192,
   exposedPorts: [{ port: 3000, auth: true }],
 });
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hyperbrowser/sdk",
-  "version": "0.88.1",
+  "version": "0.88.2",
   "description": "Node SDK for Hyperbrowser API",
   "author": "",
   "repository": {

--- a/src/services/sandboxes.ts
+++ b/src/services/sandboxes.ts
@@ -25,13 +25,13 @@ import { BaseService } from "./base";
 
 const RUNTIME_SESSION_REFRESH_BUFFER_MS = 60_000;
 
-type WireSandbox = Omit<Sandbox, "cpu" | "memory" | "disk"> & {
+type WireSandbox = Omit<Sandbox, "cpu" | "memoryMiB" | "diskMiB"> & {
   vcpus?: number | null;
   memMiB?: number | null;
   diskSizeMiB?: number | null;
 };
 
-type WireSandboxDetail = Omit<SandboxDetail, "cpu" | "memory" | "disk"> & {
+type WireSandboxDetail = Omit<SandboxDetail, "cpu" | "memoryMiB" | "diskMiB"> & {
   vcpus?: number | null;
   memMiB?: number | null;
   diskSizeMiB?: number | null;
@@ -43,7 +43,7 @@ type WireSandboxListResponse = Omit<SandboxListResponse, "sandboxes"> & {
 
 const validateOptionalPositiveInteger = (
   value: number | undefined,
-  fieldName: "cpu" | "memory" | "disk"
+  fieldName: "cpu" | "memoryMiB" | "diskMiB"
 ) => {
   if (value === undefined) {
     return;
@@ -58,8 +58,8 @@ const normalizeSandbox = (sandbox: WireSandbox): Sandbox => {
   return {
     ...rest,
     cpu: vcpus,
-    memory: memMiB,
-    disk: diskSizeMiB,
+    memoryMiB: memMiB,
+    diskMiB: diskSizeMiB,
   };
 };
 
@@ -80,8 +80,8 @@ const normalizeSandboxListResponse = (response: WireSandboxListResponse): Sandbo
 const serializeCreateSandboxParams = (params: CreateSandboxParams): Record<string, unknown> => {
   if ("imageName" in params) {
     validateOptionalPositiveInteger(params.cpu, "cpu");
-    validateOptionalPositiveInteger(params.memory, "memory");
-    validateOptionalPositiveInteger(params.disk, "disk");
+    validateOptionalPositiveInteger(params.memoryMiB, "memoryMiB");
+    validateOptionalPositiveInteger(params.diskMiB, "diskMiB");
 
     return {
       imageName: params.imageName,
@@ -91,24 +91,24 @@ const serializeCreateSandboxParams = (params: CreateSandboxParams): Record<strin
       exposedPorts: params.exposedPorts,
       timeoutMinutes: params.timeoutMinutes,
       vcpus: params.cpu,
-      memMiB: params.memory,
-      diskSizeMiB: params.disk,
+      memMiB: params.memoryMiB,
+      diskSizeMiB: params.diskMiB,
     };
   }
 
   const snapshotParams = params as CreateSandboxParams & {
     cpu?: number;
-    memory?: number;
-    disk?: number;
+    memoryMiB?: number;
+    diskMiB?: number;
   };
 
   if (
     snapshotParams.cpu !== undefined ||
-    snapshotParams.memory !== undefined ||
-    snapshotParams.disk !== undefined
+    snapshotParams.memoryMiB !== undefined ||
+    snapshotParams.diskMiB !== undefined
   ) {
     throw new HyperbrowserError(
-      "cpu, memory, and disk are only supported for image launches",
+      "cpu, memoryMiB, and diskMiB are only supported for image launches",
       undefined
     );
   }
@@ -210,12 +210,12 @@ export class SandboxHandle {
     return this.detail.cpu;
   }
 
-  get memory(): number | null | undefined {
-    return this.detail.memory;
+  get memoryMiB(): number | null | undefined {
+    return this.detail.memoryMiB;
   }
 
-  get disk(): number | null | undefined {
-    return this.detail.disk;
+  get diskMiB(): number | null | undefined {
+    return this.detail.diskMiB;
   }
 
   get exposedPorts(): SandboxExposeResult[] {

--- a/src/services/sandboxes.ts
+++ b/src/services/sandboxes.ts
@@ -6,6 +6,7 @@ import { SandboxTerminalApi } from "../sandbox/terminal";
 import { BasicResponse } from "../types/session";
 import {
   CreateSandboxParams,
+  Sandbox,
   SandboxDetail,
   SandboxExposeParams,
   SandboxExposeResult,
@@ -24,6 +25,104 @@ import { BaseService } from "./base";
 
 const RUNTIME_SESSION_REFRESH_BUFFER_MS = 60_000;
 
+type WireSandbox = Omit<Sandbox, "cpu" | "memory" | "disk"> & {
+  vcpus?: number | null;
+  memMiB?: number | null;
+  diskSizeMiB?: number | null;
+};
+
+type WireSandboxDetail = Omit<SandboxDetail, "cpu" | "memory" | "disk"> & {
+  vcpus?: number | null;
+  memMiB?: number | null;
+  diskSizeMiB?: number | null;
+};
+
+type WireSandboxListResponse = Omit<SandboxListResponse, "sandboxes"> & {
+  sandboxes: WireSandbox[];
+};
+
+const validateOptionalPositiveInteger = (
+  value: number | undefined,
+  fieldName: "cpu" | "memory" | "disk"
+) => {
+  if (value === undefined) {
+    return;
+  }
+  if (!Number.isInteger(value) || value < 1) {
+    throw new HyperbrowserError(`${fieldName} must be a positive integer`, undefined);
+  }
+};
+
+const normalizeSandbox = (sandbox: WireSandbox): Sandbox => {
+  const { vcpus, memMiB, diskSizeMiB, ...rest } = sandbox;
+  return {
+    ...rest,
+    cpu: vcpus,
+    memory: memMiB,
+    disk: diskSizeMiB,
+  };
+};
+
+const normalizeSandboxDetail = (detail: WireSandboxDetail): SandboxDetail => {
+  const { token, tokenExpiresAt, ...sandbox } = detail;
+  return {
+    ...normalizeSandbox(sandbox),
+    token,
+    tokenExpiresAt,
+  };
+};
+
+const normalizeSandboxListResponse = (response: WireSandboxListResponse): SandboxListResponse => ({
+  ...response,
+  sandboxes: response.sandboxes.map(normalizeSandbox),
+});
+
+const serializeCreateSandboxParams = (params: CreateSandboxParams): Record<string, unknown> => {
+  if ("imageName" in params) {
+    validateOptionalPositiveInteger(params.cpu, "cpu");
+    validateOptionalPositiveInteger(params.memory, "memory");
+    validateOptionalPositiveInteger(params.disk, "disk");
+
+    return {
+      imageName: params.imageName,
+      imageId: params.imageId,
+      region: params.region,
+      enableRecording: params.enableRecording,
+      exposedPorts: params.exposedPorts,
+      timeoutMinutes: params.timeoutMinutes,
+      vcpus: params.cpu,
+      memMiB: params.memory,
+      diskSizeMiB: params.disk,
+    };
+  }
+
+  const snapshotParams = params as CreateSandboxParams & {
+    cpu?: number;
+    memory?: number;
+    disk?: number;
+  };
+
+  if (
+    snapshotParams.cpu !== undefined ||
+    snapshotParams.memory !== undefined ||
+    snapshotParams.disk !== undefined
+  ) {
+    throw new HyperbrowserError(
+      "cpu, memory, and disk are only supported for image launches",
+      undefined
+    );
+  }
+
+  return {
+    snapshotName: snapshotParams.snapshotName,
+    snapshotId: snapshotParams.snapshotId,
+    region: snapshotParams.region,
+    enableRecording: snapshotParams.enableRecording,
+    exposedPorts: snapshotParams.exposedPorts,
+    timeoutMinutes: snapshotParams.timeoutMinutes,
+  };
+};
+
 type SandboxRuntimeState = {
   sandboxId: string;
   status: SandboxDetail["status"];
@@ -33,10 +132,7 @@ type SandboxRuntimeState = {
   runtime: SandboxDetail["runtime"];
 };
 
-const buildSandboxExposedUrl = (
-  runtime: SandboxDetail["runtime"],
-  port: number
-): string => {
+const buildSandboxExposedUrl = (runtime: SandboxDetail["runtime"], port: number): string => {
   const baseUrl = new URL(runtime.baseUrl);
   const authority = baseUrl.port
     ? `${port}-${runtime.host}:${baseUrl.port}`
@@ -108,6 +204,18 @@ export class SandboxHandle {
 
   get sessionUrl(): string {
     return this.detail.sessionUrl;
+  }
+
+  get cpu(): number | null | undefined {
+    return this.detail.cpu;
+  }
+
+  get memory(): number | null | undefined {
+    return this.detail.memory;
+  }
+
+  get disk(): number | null | undefined {
+    return this.detail.disk;
   }
 
   get exposedPorts(): SandboxExposeResult[] {
@@ -324,7 +432,7 @@ export class SandboxesService extends BaseService {
 
   async list(params: SandboxListParams = {}): Promise<SandboxListResponse> {
     try {
-      return await this.request<SandboxListResponse>("/sandboxes", undefined, {
+      const response = await this.request<WireSandboxListResponse>("/sandboxes", undefined, {
         status: params.status,
         start: params.start,
         end: params.end,
@@ -332,6 +440,7 @@ export class SandboxesService extends BaseService {
         page: params.page,
         limit: params.limit,
       });
+      return normalizeSandboxListResponse(response);
     } catch (error) {
       if (error instanceof HyperbrowserError) {
         throw error;
@@ -383,7 +492,8 @@ export class SandboxesService extends BaseService {
 
   async getDetail(id: string): Promise<SandboxDetail> {
     try {
-      return await this.request<SandboxDetail>(`/sandbox/${id}`);
+      const detail = await this.request<WireSandboxDetail>(`/sandbox/${id}`);
+      return normalizeSandboxDetail(detail);
     } catch (error) {
       if (error instanceof HyperbrowserError) {
         throw error;
@@ -413,10 +523,7 @@ export class SandboxesService extends BaseService {
     }
   }
 
-  async expose(
-    id: string,
-    params: SandboxExposeParams
-  ): Promise<SandboxExposeResult> {
+  async expose(id: string, params: SandboxExposeParams): Promise<SandboxExposeResult> {
     try {
       return await this.request<SandboxExposeResult>(`/sandbox/${id}/expose`, {
         method: "POST",
@@ -446,10 +553,11 @@ export class SandboxesService extends BaseService {
 
   private async createDetail(params: CreateSandboxParams): Promise<SandboxDetail> {
     try {
-      return await this.request<SandboxDetail>("/sandbox", {
+      const detail = await this.request<WireSandboxDetail>("/sandbox", {
         method: "POST",
-        body: JSON.stringify(params),
+        body: JSON.stringify(serializeCreateSandboxParams(params)),
       });
+      return normalizeSandboxDetail(detail);
     } catch (error) {
       if (error instanceof HyperbrowserError) {
         throw error;

--- a/src/types/sandbox.contract.d.ts
+++ b/src/types/sandbox.contract.d.ts
@@ -11,7 +11,29 @@ type SnapshotSourceAllowed = { snapshotName: "snapshot" } extends CreateSandboxP
   : false;
 
 type ImageSourceAllowed = { imageName: "image" } extends CreateSandboxParams ? true : false;
+type ImageCpuAllowed = { imageName: "image"; cpu: 2 } extends CreateSandboxParams ? true : false;
+type ImageMemoryAllowed = { imageName: "image"; memory: 2048 } extends CreateSandboxParams
+  ? true
+  : false;
+type ImageDiskAllowed = { imageName: "image"; disk: 8192 } extends CreateSandboxParams
+  ? true
+  : false;
+type SnapshotCpuAllowed = { snapshotName: "snapshot"; cpu: 2 } extends CreateSandboxParams
+  ? true
+  : false;
+type SnapshotMemoryAllowed = { snapshotName: "snapshot"; memory: 2048 } extends CreateSandboxParams
+  ? true
+  : false;
+type SnapshotDiskAllowed = { snapshotName: "snapshot"; disk: 8192 } extends CreateSandboxParams
+  ? true
+  : false;
 
 type _NoSandboxNameSource = Assert<HasSandboxNameSource extends false ? true : false>;
 type _SnapshotSourceAllowed = Assert<SnapshotSourceAllowed>;
 type _ImageSourceAllowed = Assert<ImageSourceAllowed>;
+type _ImageCpuAllowed = Assert<ImageCpuAllowed>;
+type _ImageMemoryAllowed = Assert<ImageMemoryAllowed>;
+type _ImageDiskAllowed = Assert<ImageDiskAllowed>;
+type _SnapshotCpuDisallowed = Assert<SnapshotCpuAllowed extends false ? true : false>;
+type _SnapshotMemoryDisallowed = Assert<SnapshotMemoryAllowed extends false ? true : false>;
+type _SnapshotDiskDisallowed = Assert<SnapshotDiskAllowed extends false ? true : false>;

--- a/src/types/sandbox.contract.d.ts
+++ b/src/types/sandbox.contract.d.ts
@@ -12,19 +12,22 @@ type SnapshotSourceAllowed = { snapshotName: "snapshot" } extends CreateSandboxP
 
 type ImageSourceAllowed = { imageName: "image" } extends CreateSandboxParams ? true : false;
 type ImageCpuAllowed = { imageName: "image"; cpu: 2 } extends CreateSandboxParams ? true : false;
-type ImageMemoryAllowed = { imageName: "image"; memory: 2048 } extends CreateSandboxParams
+type ImageMemoryAllowed = { imageName: "image"; memoryMiB: 2048 } extends CreateSandboxParams
   ? true
   : false;
-type ImageDiskAllowed = { imageName: "image"; disk: 8192 } extends CreateSandboxParams
+type ImageDiskAllowed = { imageName: "image"; diskMiB: 8192 } extends CreateSandboxParams
   ? true
   : false;
 type SnapshotCpuAllowed = { snapshotName: "snapshot"; cpu: 2 } extends CreateSandboxParams
   ? true
   : false;
-type SnapshotMemoryAllowed = { snapshotName: "snapshot"; memory: 2048 } extends CreateSandboxParams
+type SnapshotMemoryAllowed = {
+  snapshotName: "snapshot";
+  memoryMiB: 2048;
+} extends CreateSandboxParams
   ? true
   : false;
-type SnapshotDiskAllowed = { snapshotName: "snapshot"; disk: 8192 } extends CreateSandboxParams
+type SnapshotDiskAllowed = { snapshotName: "snapshot"; diskMiB: 8192 } extends CreateSandboxParams
   ? true
   : false;
 

--- a/src/types/sandbox.ts
+++ b/src/types/sandbox.ts
@@ -31,8 +31,8 @@ export interface Sandbox {
   duration: number;
   proxyBytesUsed: number;
   cpu?: number | null;
-  memory?: number | null;
-  disk?: number | null;
+  memoryMiB?: number | null;
+  diskMiB?: number | null;
   runtime: SandboxRuntimeTarget;
   exposedPorts: SandboxExposeResult[];
 }
@@ -56,8 +56,8 @@ export type CreateSandboxParams =
       imageName?: never;
       imageId?: never;
       cpu?: never;
-      memory?: never;
-      disk?: never;
+      memoryMiB?: never;
+      diskMiB?: never;
     })
   | (SandboxCreateCommonParams & {
       snapshotName?: never;
@@ -65,8 +65,8 @@ export type CreateSandboxParams =
       imageName: string;
       imageId?: string;
       cpu?: number;
-      memory?: number;
-      disk?: number;
+      memoryMiB?: number;
+      diskMiB?: number;
     });
 
 export interface SandboxListParams {

--- a/src/types/sandbox.ts
+++ b/src/types/sandbox.ts
@@ -30,6 +30,9 @@ export interface Sandbox {
   sessionUrl: string;
   duration: number;
   proxyBytesUsed: number;
+  cpu?: number | null;
+  memory?: number | null;
+  disk?: number | null;
   runtime: SandboxRuntimeTarget;
   exposedPorts: SandboxExposeResult[];
 }
@@ -52,12 +55,18 @@ export type CreateSandboxParams =
       snapshotId?: string;
       imageName?: never;
       imageId?: never;
+      cpu?: never;
+      memory?: never;
+      disk?: never;
     })
   | (SandboxCreateCommonParams & {
       snapshotName?: never;
       snapshotId?: never;
       imageName: string;
       imageId?: string;
+      cpu?: number;
+      memory?: number;
+      disk?: number;
     });
 
 export interface SandboxListParams {

--- a/tests/sandbox/e2e/resource-config.test.ts
+++ b/tests/sandbox/e2e/resource-config.test.ts
@@ -21,30 +21,30 @@ async function execInteger(sandbox: SandboxHandle, command: string): Promise<num
 }
 
 describe.sequential("sandbox resource config e2e", () => {
-  test("image launch applies cpu memory and disk sizing", async () => {
+  test("image launch applies cpu memoryMiB and diskMiB sizing", async () => {
     let sandbox: SandboxHandle | null = null;
 
     try {
       sandbox = await client.sandboxes.create({
         imageName: DEFAULT_IMAGE_NAME,
         cpu: REQUESTED_CPU,
-        memory: REQUESTED_MEMORY_MIB,
-        disk: REQUESTED_DISK_MIB,
+        memoryMiB: REQUESTED_MEMORY_MIB,
+        diskMiB: REQUESTED_DISK_MIB,
       });
 
       expect(sandbox.cpu).toBe(REQUESTED_CPU);
-      expect(sandbox.memory).toBe(REQUESTED_MEMORY_MIB);
-      expect(sandbox.disk).toBe(REQUESTED_DISK_MIB);
+      expect(sandbox.memoryMiB).toBe(REQUESTED_MEMORY_MIB);
+      expect(sandbox.diskMiB).toBe(REQUESTED_DISK_MIB);
 
       const detail = await sandbox.info();
       expect(detail.cpu).toBe(REQUESTED_CPU);
-      expect(detail.memory).toBe(REQUESTED_MEMORY_MIB);
-      expect(detail.disk).toBe(REQUESTED_DISK_MIB);
+      expect(detail.memoryMiB).toBe(REQUESTED_MEMORY_MIB);
+      expect(detail.diskMiB).toBe(REQUESTED_DISK_MIB);
 
       const reloaded = await client.sandboxes.get(sandbox.id);
       expect(reloaded.cpu).toBe(REQUESTED_CPU);
-      expect(reloaded.memory).toBe(REQUESTED_MEMORY_MIB);
-      expect(reloaded.disk).toBe(REQUESTED_DISK_MIB);
+      expect(reloaded.memoryMiB).toBe(REQUESTED_MEMORY_MIB);
+      expect(reloaded.diskMiB).toBe(REQUESTED_DISK_MIB);
 
       await waitForRuntimeReady(sandbox);
 

--- a/tests/sandbox/e2e/resource-config.test.ts
+++ b/tests/sandbox/e2e/resource-config.test.ts
@@ -1,0 +1,67 @@
+import { describe, expect, test } from "vitest";
+import type { SandboxHandle } from "../../../src/services/sandboxes";
+import { createClient, DEFAULT_IMAGE_NAME } from "../../helpers/config";
+import { stopSandboxIfRunning, waitForRuntimeReady } from "../../helpers/sandbox";
+
+const client = createClient();
+
+const REQUESTED_CPU = 8;
+const REQUESTED_MEMORY_MIB = 8192;
+const REQUESTED_DISK_MIB = 10240;
+const MEMORY_MIN_VISIBLE_MIB = REQUESTED_MEMORY_MIB - 512;
+const DISK_MIN_VISIBLE_MIB = REQUESTED_DISK_MIB - 512;
+
+async function execInteger(sandbox: SandboxHandle, command: string): Promise<number> {
+  const result = await sandbox.exec(command);
+  expect(result.exitCode).toBe(0);
+
+  const value = Number.parseInt(result.stdout.trim(), 10);
+  expect(Number.isFinite(value)).toBe(true);
+  return value;
+}
+
+describe.sequential("sandbox resource config e2e", () => {
+  test("image launch applies cpu memory and disk sizing", async () => {
+    let sandbox: SandboxHandle | null = null;
+
+    try {
+      sandbox = await client.sandboxes.create({
+        imageName: DEFAULT_IMAGE_NAME,
+        cpu: REQUESTED_CPU,
+        memory: REQUESTED_MEMORY_MIB,
+        disk: REQUESTED_DISK_MIB,
+      });
+
+      expect(sandbox.cpu).toBe(REQUESTED_CPU);
+      expect(sandbox.memory).toBe(REQUESTED_MEMORY_MIB);
+      expect(sandbox.disk).toBe(REQUESTED_DISK_MIB);
+
+      const detail = await sandbox.info();
+      expect(detail.cpu).toBe(REQUESTED_CPU);
+      expect(detail.memory).toBe(REQUESTED_MEMORY_MIB);
+      expect(detail.disk).toBe(REQUESTED_DISK_MIB);
+
+      const reloaded = await client.sandboxes.get(sandbox.id);
+      expect(reloaded.cpu).toBe(REQUESTED_CPU);
+      expect(reloaded.memory).toBe(REQUESTED_MEMORY_MIB);
+      expect(reloaded.disk).toBe(REQUESTED_DISK_MIB);
+
+      await waitForRuntimeReady(sandbox);
+
+      const cpuCount = await execInteger(sandbox, "nproc");
+      const memoryMiB = await execInteger(
+        sandbox,
+        "awk '/MemTotal/ {printf \"%.0f\\n\", $2/1024}' /proc/meminfo"
+      );
+      const diskMiB = await execInteger(sandbox, "df -m / | awk 'NR==2 {print $2}'");
+
+      expect(cpuCount).toBe(REQUESTED_CPU);
+      expect(memoryMiB).toBeGreaterThanOrEqual(MEMORY_MIN_VISIBLE_MIB);
+      expect(memoryMiB).toBeLessThanOrEqual(REQUESTED_MEMORY_MIB);
+      expect(diskMiB).toBeGreaterThanOrEqual(DISK_MIN_VISIBLE_MIB);
+      expect(diskMiB).toBeLessThanOrEqual(REQUESTED_DISK_MIB);
+    } finally {
+      await stopSandboxIfRunning(sandbox);
+    }
+  });
+});

--- a/tests/sandbox/e2e/sandbox-contract.test.ts
+++ b/tests/sandbox/e2e/sandbox-contract.test.ts
@@ -5,9 +5,7 @@ import * as wsModule from "../../../src/sandbox/ws";
 import { SandboxesService } from "../../../src/services/sandboxes";
 import type { SandboxExposeResult } from "../../../src/types";
 
-const wireSandboxDetail = (
-  overrides: Record<string, unknown> = {}
-): Record<string, unknown> => ({
+const wireSandboxDetail = (overrides: Record<string, unknown> = {}): Record<string, unknown> => ({
   id: "sbx_123",
   teamId: "team_1",
   status: "active",
@@ -63,8 +61,8 @@ describe("sandbox control and runtime contract", () => {
     const sandbox = await service.create({
       imageName: "node",
       cpu: 8,
-      memory: 8192,
-      disk: 10240,
+      memoryMiB: 8192,
+      diskMiB: 10240,
       exposedPorts: [{ port: 3000, auth: true }],
     });
 
@@ -84,8 +82,8 @@ describe("sandbox control and runtime contract", () => {
     expect(sandbox.exposedPorts).toEqual(payload.exposedPorts as SandboxExposeResult[]);
     expect(sandbox.toJSON()).toMatchObject({
       cpu: 2,
-      memory: 2048,
-      disk: 8192,
+      memoryMiB: 2048,
+      diskMiB: 8192,
     });
     expect(sandbox.getExposedUrl(3000)).toBe("https://3000-runtime.example.com/");
   });
@@ -128,7 +126,7 @@ describe("sandbox control and runtime contract", () => {
     });
   });
 
-  test("list normalizes sandbox sizing to cpu memory and disk", async () => {
+  test("list normalizes sandbox sizing to cpu memoryMiB and diskMiB", async () => {
     const service = new SandboxesService("test-key", "https://api.example.com", 30_000);
     vi.spyOn(service as any, "request").mockResolvedValue({
       sandboxes: [
@@ -171,12 +169,12 @@ describe("sandbox control and runtime contract", () => {
 
     expect(response.sandboxes[0]).toMatchObject({
       cpu: 2,
-      memory: 2048,
-      disk: 8192,
+      memoryMiB: 2048,
+      diskMiB: 8192,
     });
   });
 
-  test("create rejects cpu memory and disk for snapshot launches", async () => {
+  test("create rejects cpu memoryMiB and diskMiB for snapshot launches", async () => {
     const service = new SandboxesService("test-key", "https://api.example.com", 30_000);
 
     await expect(
@@ -184,21 +182,18 @@ describe("sandbox control and runtime contract", () => {
         snapshotName: "snap",
         cpu: 2,
       } as any)
-    ).rejects.toThrow("cpu, memory, and disk are only supported for image launches");
+    ).rejects.toThrow("cpu, memoryMiB, and diskMiB are only supported for image launches");
   });
 
   test("batch file writes forward encoding, append, and mode per entry", async () => {
     const requestJSON = vi.fn().mockResolvedValue({
       files: [{ path: "/tmp/hello.txt", name: "hello.txt", type: "file" }],
     });
-    const files = new SandboxFilesApi(
-      { requestJSON } as any,
-      async () => ({
-        sandboxId: "sbx_123",
-        baseUrl: "https://runtime.example.com",
-        token: "runtime-token",
-      })
-    );
+    const files = new SandboxFilesApi({ requestJSON } as any, async () => ({
+      sandboxId: "sbx_123",
+      baseUrl: "https://runtime.example.com",
+      token: "runtime-token",
+    }));
 
     await files.write([
       {

--- a/tests/sandbox/e2e/sandbox-contract.test.ts
+++ b/tests/sandbox/e2e/sandbox-contract.test.ts
@@ -3,9 +3,11 @@ import { SandboxFilesApi } from "../../../src/sandbox/files";
 import { SandboxTerminalHandle } from "../../../src/sandbox/terminal";
 import * as wsModule from "../../../src/sandbox/ws";
 import { SandboxesService } from "../../../src/services/sandboxes";
-import type { SandboxDetail } from "../../../src/types";
+import type { SandboxExposeResult } from "../../../src/types";
 
-const sandboxDetail = (overrides: Partial<SandboxDetail> = {}): SandboxDetail => ({
+const wireSandboxDetail = (
+  overrides: Record<string, unknown> = {}
+): Record<string, unknown> => ({
   id: "sbx_123",
   teamId: "team_1",
   status: "active",
@@ -24,6 +26,9 @@ const sandboxDetail = (overrides: Partial<SandboxDetail> = {}): SandboxDetail =>
   sessionUrl: "https://example.com/session",
   duration: 10,
   proxyBytesUsed: 3,
+  vcpus: 2,
+  memMiB: 2048,
+  diskSizeMiB: 8192,
   runtime: {
     transport: "regional_proxy",
     host: "runtime.example.com",
@@ -42,7 +47,7 @@ afterEach(() => {
 describe("sandbox control and runtime contract", () => {
   test("create forwards exposedPorts and hydrates handle exposed ports", async () => {
     const service = new SandboxesService("test-key", "https://api.example.com", 30_000);
-    const payload = sandboxDetail({
+    const payload = wireSandboxDetail({
       exposedPorts: [
         {
           port: 3000,
@@ -57,17 +62,31 @@ describe("sandbox control and runtime contract", () => {
 
     const sandbox = await service.create({
       imageName: "node",
+      cpu: 8,
+      memory: 8192,
+      disk: 10240,
       exposedPorts: [{ port: 3000, auth: true }],
     });
 
-    expect(requestSpy).toHaveBeenCalledWith("/sandbox", {
-      method: "POST",
-      body: JSON.stringify({
-        imageName: "node",
-        exposedPorts: [{ port: 3000, auth: true }],
-      }),
+    expect(requestSpy).toHaveBeenCalledWith(
+      "/sandbox",
+      expect.objectContaining({
+        method: "POST",
+      })
+    );
+    expect(JSON.parse(requestSpy.mock.calls[0][1].body)).toEqual({
+      imageName: "node",
+      exposedPorts: [{ port: 3000, auth: true }],
+      vcpus: 8,
+      memMiB: 8192,
+      diskSizeMiB: 10240,
     });
-    expect(sandbox.exposedPorts).toEqual(payload.exposedPorts);
+    expect(sandbox.exposedPorts).toEqual(payload.exposedPorts as SandboxExposeResult[]);
+    expect(sandbox.toJSON()).toMatchObject({
+      cpu: 2,
+      memory: 2048,
+      disk: 8192,
+    });
     expect(sandbox.getExposedUrl(3000)).toBe("https://3000-runtime.example.com/");
   });
 
@@ -75,7 +94,7 @@ describe("sandbox control and runtime contract", () => {
     const service = new SandboxesService("test-key", "https://api.example.com", 30_000);
     const requestSpy = vi.spyOn(service as any, "request");
     requestSpy
-      .mockResolvedValueOnce(sandboxDetail())
+      .mockResolvedValueOnce(wireSandboxDetail())
       .mockResolvedValueOnce({
         port: 3000,
         auth: true,
@@ -107,6 +126,65 @@ describe("sandbox control and runtime contract", () => {
       method: "POST",
       body: JSON.stringify({ port: 3000 }),
     });
+  });
+
+  test("list normalizes sandbox sizing to cpu memory and disk", async () => {
+    const service = new SandboxesService("test-key", "https://api.example.com", 30_000);
+    vi.spyOn(service as any, "request").mockResolvedValue({
+      sandboxes: [
+        {
+          id: "sbx_123",
+          teamId: "team_1",
+          status: "active",
+          endTime: null,
+          startTime: 123,
+          createdAt: "2026-03-12T00:00:00Z",
+          updatedAt: "2026-03-12T00:00:01Z",
+          closeReason: null,
+          dataConsumed: 1,
+          proxyDataConsumed: 2,
+          usageType: "sandbox",
+          jobId: null,
+          launchState: null,
+          creditsUsed: 0.1,
+          region: "us",
+          sessionUrl: "https://example.com/session",
+          duration: 10,
+          proxyBytesUsed: 3,
+          vcpus: 2,
+          memMiB: 2048,
+          diskSizeMiB: 8192,
+          runtime: {
+            transport: "regional_proxy",
+            host: "runtime.example.com",
+            baseUrl: "https://runtime.example.com",
+          },
+          exposedPorts: [],
+        },
+      ],
+      totalCount: 1,
+      page: 1,
+      perPage: 10,
+    });
+
+    const response = await service.list();
+
+    expect(response.sandboxes[0]).toMatchObject({
+      cpu: 2,
+      memory: 2048,
+      disk: 8192,
+    });
+  });
+
+  test("create rejects cpu memory and disk for snapshot launches", async () => {
+    const service = new SandboxesService("test-key", "https://api.example.com", 30_000);
+
+    await expect(
+      service.create({
+        snapshotName: "snap",
+        cpu: 2,
+      } as any)
+    ).rejects.toThrow("cpu, memory, and disk are only supported for image launches");
   });
 
   test("batch file writes forward encoding, append, and mode per entry", async () => {


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Moderate risk because it changes the sandbox create payload shape sent to the API and normalizes new wire fields on `getDetail`/`list`, which could break compatibility if server contracts differ.
> 
> **Overview**
> Supports sandbox resource sizing by adding optional `cpu`, `memoryMiB`, and `diskMiB` to image-based `sandboxes.create()` while explicitly disallowing these fields for snapshot launches (runtime validation + type-level contract tests).
> 
> The service now **serializes** these options to the API’s wire names (`vcpus`, `memMiB`, `diskSizeMiB`) and **normalizes** `getDetail()`/`list()` responses back to the SDK’s `cpu`/`memoryMiB`/`diskMiB` fields; `SandboxHandle` exposes the new sizing getters. Documentation examples and package version are updated, and an e2e test verifies sizing is applied inside the runtime.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 0b04410c438cb686c961eb6326b7434221b9a506. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->