### PR TITLE
add gemini-3-flash-preview to gemini computer use

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hyperbrowser/sdk",
-  "version": "0.88.2",
+  "version": "0.88.3",
   "description": "Node SDK for Hyperbrowser API",
   "author": "",
   "repository": {

--- a/src/types/constants.ts
+++ b/src/types/constants.ts
@@ -76,7 +76,9 @@ export type HyperAgentLlm =
   | "gemini-2.5-flash"
   | "gemini-3-flash-preview";
 
-export type GeminiComputerUseLlm = "gemini-2.5-computer-use-preview-10-2025";
+export type GeminiComputerUseLlm =
+  | "gemini-3-flash-preview"
+  | "gemini-2.5-computer-use-preview-10-2025";
 
 export type SessionRegion =
   | "us-central"


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Low risk: this is a small TypeScript type expansion plus a patch version bump, with no runtime logic changes.
> 
> **Overview**
> Adds `gemini-3-flash-preview` as an allowed value for `GeminiComputerUseLlm`, enabling Gemini computer-use sessions to target that model in the SDK type surface.
> 
> Bumps the package version from `0.88.2` to `0.88.3`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit a529bbcd4140350dd3d586997f47a476b519df18. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->