### PR TITLE
fix web types

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hyperbrowser/sdk",
-  "version": "0.88.3",
+  "version": "0.88.4",
   "description": "Node SDK for Hyperbrowser API",
   "author": "",
   "repository": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hyperbrowser/sdk",
-  "version": "0.88.4",
+  "version": "0.89.0",
   "description": "Node SDK for Hyperbrowser API",
   "author": "",
   "repository": {

--- a/src/types/crawl.ts
+++ b/src/types/crawl.ts
@@ -26,7 +26,7 @@ export interface CrawledPage {
   url: string;
   status: CrawlPageStatus;
   error?: string | null;
-  metadata?: Record<string, string | string[]>;
+  metadata?: Record<string, unknown>;
   markdown?: string;
   html?: string;
   links?: string[];

--- a/src/types/scrape.ts
+++ b/src/types/scrape.ts
@@ -48,7 +48,7 @@ export interface ScrapeJobStatusResponse {
 }
 
 export interface ScrapeJobData {
-  metadata?: Record<string, string | string[]>;
+  metadata?: Record<string, unknown>;
   markdown?: string;
   html?: string;
   links?: string[];
@@ -72,7 +72,7 @@ export interface ScrapedPage {
   url: string;
   status: ScrapePageStatus;
   error?: string | null;
-  metadata?: Record<string, string | string[]>;
+  metadata?: Record<string, unknown>;
   markdown?: string;
   html?: string;
   links?: string[];

--- a/src/types/web/common.ts
+++ b/src/types/web/common.ts
@@ -30,7 +30,7 @@ export interface PageData {
   url: string;
   status: PageStatus;
   error?: string;
-  metadata?: Record<string, string | string[]>;
+  metadata?: Record<string, unknown>;
   markdown?: string;
   html?: string;
   links?: string[];
@@ -85,7 +85,7 @@ export interface FetchOutputOptions {
 export interface FetchBrowserOptions {
   screen?: ScreenConfig;
   profileId?: string;
-  solveCaptchas?: string;
+  solveCaptchas?: boolean;
   location?: FetchBrowserLocationOptions;
 }
 

--- a/src/types/web/fetch.ts
+++ b/src/types/web/fetch.ts
@@ -18,7 +18,7 @@ export interface FetchParams {
 }
 
 export interface FetchResponseData {
-  metadata?: Record<string, string | string[]>;
+  metadata?: Record<string, unknown>;
   html?: string;
   markdown?: string;
   links?: string[];


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Type changes in exported SDK interfaces are potentially breaking for TypeScript consumers (e.g., `solveCaptchas` and `metadata`), though runtime behavior is unaffected.
> 
> **Overview**
> Updates the SDK’s public TypeScript types to better match API behavior: `metadata` on crawl/scrape/fetch responses is widened from `Record<string, string | string[]>` to `Record<string, unknown>`.
> 
> Fixes `FetchBrowserOptions.solveCaptchas` to be a `boolean` (instead of `string`) and bumps the package version to `0.89.0`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 412436a8adf1698f85fbc0b071acfec1fe255d74. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->