### PR TITLE
Add volume mounts

### DIFF
--- a/README.md
+++ b/README.md
@@ -255,6 +255,27 @@ const sandbox = await client.sandboxes.create({
 console.log(sandbox.exposedPorts[0].browserUrl);
 ```
 
+Manage volumes and mount them into a sandbox:
+
+```typescript
+const volume = await client.volumes.create({ name: "project-cache" });
+const volumes = await client.volumes.list();
+const sameVolume = await client.volumes.get(volume.id);
+
+const sandbox = await client.sandboxes.create({
+  imageName: "node",
+  mounts: {
+    "/workspace/cache": {
+      id: sameVolume.id,
+      type: "rw",
+      shared: true,
+    },
+  },
+});
+
+await sandbox.stop();
+```
+
 List sandboxes with time-range and search filters:
 
 ```typescript

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hyperbrowser/sdk",
-  "version": "0.89.1",
+  "version": "0.89.2",
   "description": "Node SDK for Hyperbrowser API",
   "author": "",
   "repository": {

--- a/src/client.ts
+++ b/src/client.ts
@@ -14,6 +14,7 @@ import { ComputerActionService } from "./services/computer-action";
 import { GeminiComputerUseService } from "./services/agents/gemini-computer-use";
 import { WebService } from "./services/web";
 import { SandboxesService } from "./services/sandboxes";
+import { VolumesService } from "./services/volumes";
 
 export type HyperbrowserService = "control" | "runtime";
 
@@ -70,6 +71,7 @@ export class HyperbrowserClient {
   public readonly team: TeamService;
   public readonly computerAction: ComputerActionService;
   public readonly sandboxes: SandboxesService;
+  public readonly volumes: VolumesService;
 
   constructor(config: HyperbrowserConfig = {}) {
     const apiKey = config.apiKey || process.env["HYPERBROWSER_API_KEY"];
@@ -92,6 +94,7 @@ export class HyperbrowserClient {
     this.team = new TeamService(apiKey, baseUrl, timeout);
     this.computerAction = new ComputerActionService(apiKey, baseUrl, timeout);
     this.sandboxes = new SandboxesService(apiKey, baseUrl, timeout, runtimeProxyOverride);
+    this.volumes = new VolumesService(apiKey, baseUrl, timeout);
 
     this.agents = {
       browserUse: new BrowserUseService(apiKey, baseUrl, timeout),

--- a/src/sandbox/process.ts
+++ b/src/sandbox/process.ts
@@ -124,9 +124,7 @@ const quoteShellToken = (token: string): string => {
     return "''";
   }
 
-  return SHELL_SAFE_TOKEN_PATTERN.test(token)
-    ? token
-    : `'${token.replace(/'/g, `'\"'\"'`)}'`;
+  return SHELL_SAFE_TOKEN_PATTERN.test(token) ? token : `'${token.replace(/'/g, `'"'"'`)}'`;
 };
 
 const buildShellCommand = (command: string, args?: string[]): string => {

--- a/src/services/sandboxes.ts
+++ b/src/services/sandboxes.ts
@@ -90,6 +90,7 @@ const serializeCreateSandboxParams = (params: CreateSandboxParams): Record<strin
       region: params.region,
       enableRecording: params.enableRecording,
       exposedPorts: params.exposedPorts,
+      mounts: params.mounts,
       timeoutMinutes: params.timeoutMinutes,
       vcpus: params.cpu,
       memMiB: params.memoryMiB,
@@ -120,6 +121,7 @@ const serializeCreateSandboxParams = (params: CreateSandboxParams): Record<strin
     region: snapshotParams.region,
     enableRecording: snapshotParams.enableRecording,
     exposedPorts: snapshotParams.exposedPorts,
+    mounts: snapshotParams.mounts,
     timeoutMinutes: snapshotParams.timeoutMinutes,
   };
 };

--- a/src/services/volumes.ts
+++ b/src/services/volumes.ts
@@ -1,0 +1,50 @@
+import { HyperbrowserError } from "../client";
+import { CreateVolumeParams, Volume, VolumeListResponse } from "../types/volume";
+import { BaseService } from "./base";
+
+export class VolumesService extends BaseService {
+  /**
+   * Create a new sandbox volume.
+   */
+  async create(params: CreateVolumeParams): Promise<Volume> {
+    try {
+      return await this.request<Volume>("/volume", {
+        method: "POST",
+        body: JSON.stringify(params),
+      });
+    } catch (error) {
+      if (error instanceof HyperbrowserError) {
+        throw error;
+      }
+      throw new HyperbrowserError("Failed to create volume", undefined);
+    }
+  }
+
+  /**
+   * List sandbox volumes for the current team.
+   */
+  async list(): Promise<VolumeListResponse> {
+    try {
+      return await this.request<VolumeListResponse>("/volume");
+    } catch (error) {
+      if (error instanceof HyperbrowserError) {
+        throw error;
+      }
+      throw new HyperbrowserError("Failed to list volumes", undefined);
+    }
+  }
+
+  /**
+   * Get a single sandbox volume.
+   */
+  async get(id: string): Promise<Volume> {
+    try {
+      return await this.request<Volume>(`/volume/${id}`);
+    } catch (error) {
+      if (error instanceof HyperbrowserError) {
+        throw error;
+      }
+      throw new HyperbrowserError(`Failed to get volume ${id}`, undefined);
+    }
+  }
+}

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -123,6 +123,8 @@ export {
   SandboxRuntimeTarget,
   Sandbox,
   SandboxDetail,
+  SandboxVolumeMountType,
+  SandboxVolumeMount,
   SandboxListParams,
   SandboxListResponse,
   SandboxImageSummary,
@@ -175,6 +177,7 @@ export {
   SandboxTerminalKillParams,
   SandboxTerminalEvent,
 } from "./sandbox";
+export { CreateVolumeParams, Volume, VolumeListResponse } from "./volume";
 export {
   CreateProfileParams,
   ProfileResponse,

--- a/src/types/sandbox.contract.d.ts
+++ b/src/types/sandbox.contract.d.ts
@@ -18,6 +18,12 @@ type ImageMemoryAllowed = { imageName: "image"; memoryMiB: 2048 } extends Create
 type ImageDiskAllowed = { imageName: "image"; diskMiB: 8192 } extends CreateSandboxParams
   ? true
   : false;
+type ImageMountsAllowed = {
+  imageName: "image";
+  mounts: { "/workspace": { id: "00000000-0000-0000-0000-000000000000" } };
+} extends CreateSandboxParams
+  ? true
+  : false;
 type SnapshotCpuAllowed = { snapshotName: "snapshot"; cpu: 2 } extends CreateSandboxParams
   ? true
   : false;
@@ -30,6 +36,12 @@ type SnapshotMemoryAllowed = {
 type SnapshotDiskAllowed = { snapshotName: "snapshot"; diskMiB: 8192 } extends CreateSandboxParams
   ? true
   : false;
+type SnapshotMountsAllowed = {
+  snapshotName: "snapshot";
+  mounts: { "/workspace": { id: "00000000-0000-0000-0000-000000000000"; type: "ro" } };
+} extends CreateSandboxParams
+  ? true
+  : false;
 
 type _NoSandboxNameSource = Assert<HasSandboxNameSource extends false ? true : false>;
 type _SnapshotSourceAllowed = Assert<SnapshotSourceAllowed>;
@@ -37,6 +49,8 @@ type _ImageSourceAllowed = Assert<ImageSourceAllowed>;
 type _ImageCpuAllowed = Assert<ImageCpuAllowed>;
 type _ImageMemoryAllowed = Assert<ImageMemoryAllowed>;
 type _ImageDiskAllowed = Assert<ImageDiskAllowed>;
+type _ImageMountsAllowed = Assert<ImageMountsAllowed>;
 type _SnapshotCpuDisallowed = Assert<SnapshotCpuAllowed extends false ? true : false>;
 type _SnapshotMemoryDisallowed = Assert<SnapshotMemoryAllowed extends false ? true : false>;
 type _SnapshotDiskDisallowed = Assert<SnapshotDiskAllowed extends false ? true : false>;
+type _SnapshotMountsAllowed = Assert<SnapshotMountsAllowed>;

--- a/src/types/sandbox.ts
+++ b/src/types/sandbox.ts
@@ -42,10 +42,19 @@ export interface SandboxDetail extends Sandbox {
   tokenExpiresAt: string | null;
 }
 
+export type SandboxVolumeMountType = "rw" | "ro";
+
+export interface SandboxVolumeMount {
+  id: string;
+  type?: SandboxVolumeMountType;
+  shared?: boolean;
+}
+
 interface SandboxCreateCommonParams {
   region?: SessionRegion;
   enableRecording?: boolean;
   exposedPorts?: SandboxExposeParams[];
+  mounts?: Record<string, SandboxVolumeMount>;
   timeoutMinutes?: number;
 }
 

--- a/src/types/volume.ts
+++ b/src/types/volume.ts
@@ -1,0 +1,14 @@
+export interface CreateVolumeParams {
+  name: string;
+}
+
+export interface Volume {
+  id: string;
+  name: string;
+  size?: number;
+  transferAmount?: number;
+}
+
+export interface VolumeListResponse {
+  volumes: Volume[];
+}

--- a/tests/sandbox/e2e/sandbox-contract.test.ts
+++ b/tests/sandbox/e2e/sandbox-contract.test.ts
@@ -43,7 +43,7 @@ afterEach(() => {
 });
 
 describe("sandbox control and runtime contract", () => {
-  test("create forwards exposedPorts and hydrates handle exposed ports", async () => {
+  test("create forwards exposedPorts and mounts, then hydrates handle exposed ports", async () => {
     const service = new SandboxesService("test-key", "https://api.example.com", 30_000);
     const payload = wireSandboxDetail({
       exposedPorts: [
@@ -64,6 +64,13 @@ describe("sandbox control and runtime contract", () => {
       memoryMiB: 8192,
       diskMiB: 10240,
       exposedPorts: [{ port: 3000, auth: true }],
+      mounts: {
+        "/workspace/cache": {
+          id: "2d6f01cf-c5d7-4c61-ae9e-0264f1c8063d",
+          type: "rw",
+          shared: true,
+        },
+      },
     });
 
     expect(requestSpy).toHaveBeenCalledWith(
@@ -75,6 +82,13 @@ describe("sandbox control and runtime contract", () => {
     expect(JSON.parse(requestSpy.mock.calls[0][1].body)).toEqual({
       imageName: "node",
       exposedPorts: [{ port: 3000, auth: true }],
+      mounts: {
+        "/workspace/cache": {
+          id: "2d6f01cf-c5d7-4c61-ae9e-0264f1c8063d",
+          type: "rw",
+          shared: true,
+        },
+      },
       vcpus: 8,
       memMiB: 8192,
       diskSizeMiB: 10240,
@@ -86,6 +100,37 @@ describe("sandbox control and runtime contract", () => {
       diskMiB: 8192,
     });
     expect(sandbox.getExposedUrl(3000)).toBe("https://3000-runtime.example.com/");
+  });
+
+  test("create forwards mounts for snapshot launches", async () => {
+    const service = new SandboxesService("test-key", "https://api.example.com", 30_000);
+    const requestSpy = vi.spyOn(service as any, "request").mockResolvedValue(wireSandboxDetail());
+
+    await service.create({
+      snapshotName: "snapshot-1",
+      mounts: {
+        "/workspace/readonly": {
+          id: "2d6f01cf-c5d7-4c61-ae9e-0264f1c8063d",
+          type: "ro",
+        },
+      },
+    });
+
+    expect(requestSpy).toHaveBeenCalledWith(
+      "/sandbox",
+      expect.objectContaining({
+        method: "POST",
+      })
+    );
+    expect(JSON.parse(requestSpy.mock.calls[0][1].body)).toEqual({
+      snapshotName: "snapshot-1",
+      mounts: {
+        "/workspace/readonly": {
+          id: "2d6f01cf-c5d7-4c61-ae9e-0264f1c8063d",
+          type: "ro",
+        },
+      },
+    });
   });
 
   test("expose and unexpose preserve server fields and update cached exposed ports", async () => {

--- a/tests/sandbox/e2e/volumes-contract.test.ts
+++ b/tests/sandbox/e2e/volumes-contract.test.ts
@@ -1,0 +1,64 @@
+import { describe, expect, test, vi } from "vitest";
+import { VolumesService } from "../../../src/services/volumes";
+
+describe("volume control contract", () => {
+  test("create forwards payload and returns created volume", async () => {
+    const service = new VolumesService("test-key", "https://api.example.com", 30_000);
+    const payload = {
+      id: "2d6f01cf-c5d7-4c61-ae9e-0264f1c8063d",
+      name: "project-cache",
+      size: 0,
+      transferAmount: 0,
+    };
+
+    const requestSpy = vi.spyOn(service as any, "request").mockResolvedValue(payload);
+
+    const response = await service.create({
+      name: "project-cache",
+    });
+
+    expect(requestSpy).toHaveBeenCalledWith("/volume", {
+      method: "POST",
+      body: JSON.stringify({
+        name: "project-cache",
+      }),
+    });
+    expect(response).toEqual(payload);
+  });
+
+  test("list returns wrapped volumes response", async () => {
+    const service = new VolumesService("test-key", "https://api.example.com", 30_000);
+    const payload = {
+      volumes: [
+        {
+          id: "2d6f01cf-c5d7-4c61-ae9e-0264f1c8063d",
+          name: "project-cache",
+          size: 0,
+          transferAmount: 0,
+        },
+      ],
+    };
+
+    const requestSpy = vi.spyOn(service as any, "request").mockResolvedValue(payload);
+
+    const response = await service.list();
+
+    expect(requestSpy).toHaveBeenCalledWith("/volume");
+    expect(response).toEqual(payload);
+  });
+
+  test("get returns a single volume payload", async () => {
+    const service = new VolumesService("test-key", "https://api.example.com", 30_000);
+    const payload = {
+      id: "2d6f01cf-c5d7-4c61-ae9e-0264f1c8063d",
+      name: "project-cache",
+    };
+
+    const requestSpy = vi.spyOn(service as any, "request").mockResolvedValue(payload);
+
+    const response = await service.get("2d6f01cf-c5d7-4c61-ae9e-0264f1c8063d");
+
+    expect(requestSpy).toHaveBeenCalledWith("/volume/2d6f01cf-c5d7-4c61-ae9e-0264f1c8063d");
+    expect(response).toEqual(payload);
+  });
+});


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Adds a new volumes control API and passes `mounts` through sandbox creation, which changes request payloads and public types. Also tweaks shell-quoting for process execution, which could affect commands containing single quotes.
> 
> **Overview**
> Adds first-class **volume management** to the SDK via `client.volumes` with `create`, `list`, and `get` calls against the `/volume` endpoints, plus new exported `volume` types.
> 
> Extends sandbox creation to accept and forward `mounts` (volume ID + `ro`/`rw` + sharing) for both image and snapshot launches, updates type-level contracts/tests, and documents the new volume+mount workflow in `README`.
> 
> Separately, adjusts process command shell token quoting for safer handling of single quotes, and bumps the package version to `0.89.2`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 182ba62696f916bab870ceaf68a55d93a990d4b5. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->