### PR TITLE
add opus 4.7 for claude computer use

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hyperbrowser/sdk",
-  "version": "0.89.3",
+  "version": "0.89.4",
   "description": "Node SDK for Hyperbrowser API",
   "author": "",
   "repository": {

--- a/src/types/constants.ts
+++ b/src/types/constants.ts
@@ -51,6 +51,7 @@ export type BrowserUseLlm =
 export type ClaudeComputerUseLlm =
   | "claude-opus-4-5"
   | "claude-opus-4-6"
+  | "claude-opus-4-7"
   | "claude-haiku-4-5-20251001"
   | "claude-sonnet-4-5"
   | "claude-sonnet-4-6"


### PR DESCRIPTION

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/hyperbrowserai/node-sdk/pull/73" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Type-only surface area expansion plus a version bump; no runtime logic changes.
> 
> **Overview**
> Adds `"claude-opus-4-7"` to the `ClaudeComputerUseLlm` union type so callers can select this model for Claude computer-use tasks.
> 
> Bumps the package version from `0.89.3` to `0.89.4`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 84d9444106fcff0cb0013884ed98cd26ab6850d3. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->