### PR TITLE
add gpt-5.5

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hyperbrowser/sdk",
-  "version": "0.89.5",
+  "version": "0.89.6",
   "description": "Node SDK for Hyperbrowser API",
   "author": "",
   "repository": {

--- a/src/types/constants.ts
+++ b/src/types/constants.ts
@@ -58,11 +58,12 @@ export type ClaudeComputerUseLlm =
   | "claude-sonnet-4-20250514"
   | "claude-3-7-sonnet-20250219";
 
-export type CuaLlm = "computer-use-preview" | "gpt-5.4" | "gpt-5.4-mini";
+export type CuaLlm = "computer-use-preview" | "gpt-5.4" | "gpt-5.4-mini" | "gpt-5.5";
 
 export type HyperAgentVersion = "0.8.0" | "1.1.0";
 
 export type HyperAgentLlm =
+  | "gpt-5.5"
   | "gpt-5.2"
   | "gpt-5.1"
   | "gpt-5"

--- a/src/types/web/branding.ts
+++ b/src/types/web/branding.ts
@@ -9,11 +9,7 @@ export type BrandingPersonalityTone =
   | "bold"
   | (string & {});
 
-export type BrandingPersonalityEnergy =
-  | "low"
-  | "medium"
-  | "high"
-  | (string & {});
+export type BrandingPersonalityEnergy = "low" | "medium" | "high" | (string & {});
 
 // `(string & {})` keeps the literal arm visible to autocomplete while
 // accepting any string — without it the union collapses to bare `string`.


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Low risk: this is a patch release that only expands string-union types (and a small formatting tweak), with no runtime logic changes.
> 
> **Overview**
> Adds `gpt-5.5` as an allowed model identifier for both `CuaLlm` and `HyperAgentLlm` in `src/types/constants.ts`.
> 
> Bumps the SDK version from `0.89.5` to `0.89.6` and reformats `BrandingPersonalityEnergy` in `src/types/web/branding.ts` without changing its meaning.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 54985a632f5c2a92ed3fd51f228d9bd8e2360f4e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->