### PR TITLE
add update screen size functionality

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hyperbrowser/sdk",
-  "version": "0.89.6",
+  "version": "0.89.7",
   "description": "Node SDK for Hyperbrowser API",
   "author": "",
   "repository": {

--- a/src/services/sessions.ts
+++ b/src/services/sessions.ts
@@ -398,7 +398,7 @@ export class SessionsService extends BaseService {
     }
   }
 
-  async updateScreenParams(id: string, params: UpdateSessionScreenParams): Promise<BasicResponse> {
+  async updateScreenSize(id: string, params: UpdateSessionScreenParams): Promise<BasicResponse> {
     try {
       return await this.request<BasicResponse>(`/session/${id}/update`, {
         method: "PUT",

--- a/src/services/sessions.ts
+++ b/src/services/sessions.ts
@@ -19,6 +19,7 @@ import {
   SessionEventLogListResponse,
   UpdateSessionProfileParams,
   UpdateSessionProxyParams,
+  UpdateSessionScreenParams,
   SessionGetParams,
 } from "../types/session";
 import { BaseService } from "./base";
@@ -394,6 +395,20 @@ export class SessionsService extends BaseService {
         throw error;
       }
       throw new HyperbrowserError(`Failed to update proxy for session ${id}`, undefined);
+    }
+  }
+
+  async updateScreenParams(id: string, params: UpdateSessionScreenParams): Promise<BasicResponse> {
+    try {
+      return await this.request<BasicResponse>(`/session/${id}/update`, {
+        method: "PUT",
+        body: JSON.stringify({ type: "screen", params }),
+      });
+    } catch (error) {
+      if (error instanceof HyperbrowserError) {
+        throw error;
+      }
+      throw new HyperbrowserError(`Failed to update screen for session ${id}`, undefined);
     }
   }
 

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -117,6 +117,7 @@ export {
   UpdateSessionProfileParams,
   UpdateSessionProxyLocationParams,
   UpdateSessionProxyParams,
+  UpdateSessionScreenParams,
 } from "./session";
 export {
   SandboxStatus,

--- a/src/types/session.ts
+++ b/src/types/session.ts
@@ -239,3 +239,8 @@ export interface UpdateSessionProxyParams {
   staticIpId?: string;
   location?: UpdateSessionProxyLocationParams;
 }
+
+export interface UpdateSessionScreenParams {
+  width: number;
+  height: number;
+}


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Low risk SDK change that adds a new typed wrapper around an existing session update endpoint; behavior is isolated to a new method and type export.
> 
> **Overview**
> Adds support for updating a running session’s screen size via the SDK.
> 
> Introduces `SessionsService.updateScreenSize(id, params)` which sends a `PUT /session/{id}/update` request with `{ type: "screen" }`, and adds/exports the new `UpdateSessionScreenParams` type (`width`, `height`). Also bumps the package version to `0.89.7`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 1a67765a9a5bd989ad5d6e65062c71dbf79dfc7f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->