### PR TITLE
Add AGENTS.md with Cursor Cloud dev instructions

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,20 @@
+# Node SDK Agent Guide
+
+## Cursor Cloud specific instructions
+
+### Dev commands
+
+- `yarn install` — install dependencies (also runs `yarn build` via `prepare`)
+- `yarn build` — compile TypeScript
+- `yarn lint` — ESLint
+- `yarn test` — vitest (unit + contract tests pass without a running API; e2e/integration tests need `HYPERBROWSER_API_KEY`)
+- `yarn format` — Prettier
+
+### Gotchas
+
+- `yarn install` triggers the `prepare` script which runs `yarn build`. If the
+  build fails on install, check for TypeScript errors in `src/`.
+- Integration and e2e tests (`tests/sandbox/e2e/`, `tests/integration/`) require
+  a running Hyperbrowser API and a valid `HYPERBROWSER_API_KEY`. Without these,
+  only the contract/unit tests in the suite will pass; the e2e tests fail with
+  `ECONNREFUSED`.


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Adds `AGENTS.md` with Cursor Cloud specific development instructions for the Node SDK, including:

- Dev command reference (`yarn build`, `yarn lint`, `yarn test`, `yarn format`)
- Gotcha: `yarn install` triggers `prepare` which runs `yarn build`
- Gotcha: e2e/integration tests need `HYPERBROWSER_API_KEY`; only contract/unit tests pass without it
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-fdb0a08a-00a7-41cc-9dee-15630a72c6fa"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-fdb0a08a-00a7-41cc-9dee-15630a72c6fa"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

