### PR TITLE
Add SDK API parity methods

### DIFF
--- a/src/client.ts
+++ b/src/client.ts
@@ -12,6 +12,7 @@ import { HyperAgentService } from "./services/agents/hyper-agent";
 import { TeamService } from "./services/team";
 import { ComputerActionService } from "./services/computer-action";
 import { GeminiComputerUseService } from "./services/agents/gemini-computer-use";
+import { TaskService } from "./services/agents/task";
 import { WebService } from "./services/web";
 import { SandboxesService } from "./services/sandboxes";
 import { VolumesService } from "./services/volumes";
@@ -67,6 +68,7 @@ export class HyperbrowserClient {
     cua: CuaService;
     hyperAgent: HyperAgentService;
     geminiComputerUse: GeminiComputerUseService;
+    task: TaskService;
   };
   public readonly team: TeamService;
   public readonly computerAction: ComputerActionService;
@@ -102,6 +104,7 @@ export class HyperbrowserClient {
       cua: new CuaService(apiKey, baseUrl, timeout),
       hyperAgent: new HyperAgentService(apiKey, baseUrl, timeout),
       geminiComputerUse: new GeminiComputerUseService(apiKey, baseUrl, timeout),
+      task: new TaskService(apiKey, baseUrl, timeout),
     };
   }
 }

--- a/src/services/agents/base.ts
+++ b/src/services/agents/base.ts
@@ -1,0 +1,23 @@
+import { HyperbrowserError } from "../../client";
+import { AgentTaskListParams, AgentTaskListResponse } from "../../types/agents/task";
+import { BaseService } from "../base";
+
+export abstract class AgentTaskListService extends BaseService {
+  protected abstract readonly taskPath: string;
+  protected abstract readonly taskLabel: string;
+
+  async list(params: AgentTaskListParams = {}): Promise<AgentTaskListResponse> {
+    try {
+      return await this.request<AgentTaskListResponse>(`/task/${this.taskPath}`, undefined, {
+        task: params.task,
+        page: params.page,
+        limit: params.limit,
+      });
+    } catch (error) {
+      if (error instanceof HyperbrowserError) {
+        throw error;
+      }
+      throw new HyperbrowserError(`Failed to list ${this.taskLabel} task jobs`, undefined);
+    }
+  }
+}

--- a/src/services/agents/browser-use.ts
+++ b/src/services/agents/browser-use.ts
@@ -10,29 +10,11 @@ import {
   BrowserUseTaskStatusResponse,
 } from "../../types/agents/browser-use";
 import { isZodSchema, sleep } from "../../utils";
-import { BaseService } from "../base";
-import { AgentTaskListParams, AgentTaskListResponse } from "../../types/agents/task";
+import { AgentTaskListService } from "./base";
 
-export class BrowserUseService extends BaseService {
-
-  /**
-   * List task jobs
-   * @param params Optional filters and pagination
-   */
-  async list(params: AgentTaskListParams = {}): Promise<AgentTaskListResponse> {
-    try {
-      return await this.request<AgentTaskListResponse>("/task/browser-use", undefined, {
-        task: params.task,
-        page: params.page,
-        limit: params.limit,
-      });
-    } catch (error) {
-      if (error instanceof HyperbrowserError) {
-        throw error;
-      }
-      throw new HyperbrowserError("Failed to list browser-use task jobs", undefined);
-    }
-  }
+export class BrowserUseService extends AgentTaskListService {
+  protected readonly taskPath = "browser-use";
+  protected readonly taskLabel = "browser-use";
 
   /**
    * Start a new browser-use task job

--- a/src/services/agents/browser-use.ts
+++ b/src/services/agents/browser-use.ts
@@ -11,8 +11,29 @@ import {
 } from "../../types/agents/browser-use";
 import { isZodSchema, sleep } from "../../utils";
 import { BaseService } from "../base";
+import { AgentTaskListParams, AgentTaskListResponse } from "../../types/agents/task";
 
 export class BrowserUseService extends BaseService {
+
+  /**
+   * List task jobs
+   * @param params Optional filters and pagination
+   */
+  async list(params: AgentTaskListParams = {}): Promise<AgentTaskListResponse> {
+    try {
+      return await this.request<AgentTaskListResponse>("/task/browser-use", undefined, {
+        task: params.task,
+        page: params.page,
+        limit: params.limit,
+      });
+    } catch (error) {
+      if (error instanceof HyperbrowserError) {
+        throw error;
+      }
+      throw new HyperbrowserError("Failed to list browser-use task jobs", undefined);
+    }
+  }
+
   /**
    * Start a new browser-use task job
    * @param params The parameters for the task job

--- a/src/services/agents/claude-computer-use.ts
+++ b/src/services/agents/claude-computer-use.ts
@@ -3,6 +3,7 @@ import { BasicResponse } from "../../types";
 import { POLLING_ATTEMPTS } from "../../types/constants";
 import { sleep } from "../../utils";
 import { BaseService } from "../base";
+import { AgentTaskListParams, AgentTaskListResponse } from "../../types/agents/task";
 import {
   ClaudeComputerUseTaskResponse,
   ClaudeComputerUseTaskStatusResponse,
@@ -11,6 +12,26 @@ import {
 } from "../../types/agents/claude-computer-use";
 
 export class ClaudeComputerUseService extends BaseService {
+
+  /**
+   * List task jobs
+   * @param params Optional filters and pagination
+   */
+  async list(params: AgentTaskListParams = {}): Promise<AgentTaskListResponse> {
+    try {
+      return await this.request<AgentTaskListResponse>("/task/claude-computer-use", undefined, {
+        task: params.task,
+        page: params.page,
+        limit: params.limit,
+      });
+    } catch (error) {
+      if (error instanceof HyperbrowserError) {
+        throw error;
+      }
+      throw new HyperbrowserError("Failed to list claude-computer-use task jobs", undefined);
+    }
+  }
+
   /**
    * Start a new Claude Computer Use task job
    * @param params The parameters for the task job

--- a/src/services/agents/claude-computer-use.ts
+++ b/src/services/agents/claude-computer-use.ts
@@ -2,8 +2,7 @@ import { HyperbrowserError } from "../../client";
 import { BasicResponse } from "../../types";
 import { POLLING_ATTEMPTS } from "../../types/constants";
 import { sleep } from "../../utils";
-import { BaseService } from "../base";
-import { AgentTaskListParams, AgentTaskListResponse } from "../../types/agents/task";
+import { AgentTaskListService } from "./base";
 import {
   ClaudeComputerUseTaskResponse,
   ClaudeComputerUseTaskStatusResponse,
@@ -11,26 +10,9 @@ import {
   StartClaudeComputerUseTaskResponse,
 } from "../../types/agents/claude-computer-use";
 
-export class ClaudeComputerUseService extends BaseService {
-
-  /**
-   * List task jobs
-   * @param params Optional filters and pagination
-   */
-  async list(params: AgentTaskListParams = {}): Promise<AgentTaskListResponse> {
-    try {
-      return await this.request<AgentTaskListResponse>("/task/claude-computer-use", undefined, {
-        task: params.task,
-        page: params.page,
-        limit: params.limit,
-      });
-    } catch (error) {
-      if (error instanceof HyperbrowserError) {
-        throw error;
-      }
-      throw new HyperbrowserError("Failed to list claude-computer-use task jobs", undefined);
-    }
-  }
+export class ClaudeComputerUseService extends AgentTaskListService {
+  protected readonly taskPath = "claude-computer-use";
+  protected readonly taskLabel = "claude-computer-use";
 
   /**
    * Start a new Claude Computer Use task job

--- a/src/services/agents/cua.ts
+++ b/src/services/agents/cua.ts
@@ -2,8 +2,7 @@ import { HyperbrowserError } from "../../client";
 import { BasicResponse } from "../../types";
 import { POLLING_ATTEMPTS } from "../../types/constants";
 import { sleep } from "../../utils";
-import { BaseService } from "../base";
-import { AgentTaskListParams, AgentTaskListResponse } from "../../types/agents/task";
+import { AgentTaskListService } from "./base";
 import {
   CuaTaskResponse,
   CuaTaskStatusResponse,
@@ -11,26 +10,9 @@ import {
   StartCuaTaskResponse,
 } from "../../types/agents/cua";
 
-export class CuaService extends BaseService {
-
-  /**
-   * List task jobs
-   * @param params Optional filters and pagination
-   */
-  async list(params: AgentTaskListParams = {}): Promise<AgentTaskListResponse> {
-    try {
-      return await this.request<AgentTaskListResponse>("/task/cua", undefined, {
-        task: params.task,
-        page: params.page,
-        limit: params.limit,
-      });
-    } catch (error) {
-      if (error instanceof HyperbrowserError) {
-        throw error;
-      }
-      throw new HyperbrowserError("Failed to list cua task jobs", undefined);
-    }
-  }
+export class CuaService extends AgentTaskListService {
+  protected readonly taskPath = "cua";
+  protected readonly taskLabel = "cua";
 
   /**
    * Start a new CUA task job

--- a/src/services/agents/cua.ts
+++ b/src/services/agents/cua.ts
@@ -3,6 +3,7 @@ import { BasicResponse } from "../../types";
 import { POLLING_ATTEMPTS } from "../../types/constants";
 import { sleep } from "../../utils";
 import { BaseService } from "../base";
+import { AgentTaskListParams, AgentTaskListResponse } from "../../types/agents/task";
 import {
   CuaTaskResponse,
   CuaTaskStatusResponse,
@@ -11,6 +12,26 @@ import {
 } from "../../types/agents/cua";
 
 export class CuaService extends BaseService {
+
+  /**
+   * List task jobs
+   * @param params Optional filters and pagination
+   */
+  async list(params: AgentTaskListParams = {}): Promise<AgentTaskListResponse> {
+    try {
+      return await this.request<AgentTaskListResponse>("/task/cua", undefined, {
+        task: params.task,
+        page: params.page,
+        limit: params.limit,
+      });
+    } catch (error) {
+      if (error instanceof HyperbrowserError) {
+        throw error;
+      }
+      throw new HyperbrowserError("Failed to list cua task jobs", undefined);
+    }
+  }
+
   /**
    * Start a new CUA task job
    * @param params The parameters for the task job

--- a/src/services/agents/gemini-computer-use.ts
+++ b/src/services/agents/gemini-computer-use.ts
@@ -2,8 +2,7 @@ import { HyperbrowserError } from "../../client";
 import { BasicResponse } from "../../types";
 import { POLLING_ATTEMPTS } from "../../types/constants";
 import { sleep } from "../../utils";
-import { BaseService } from "../base";
-import { AgentTaskListParams, AgentTaskListResponse } from "../../types/agents/task";
+import { AgentTaskListService } from "./base";
 import {
   GeminiComputerUseTaskResponse,
   GeminiComputerUseTaskStatusResponse,
@@ -11,26 +10,9 @@ import {
   StartGeminiComputerUseTaskResponse,
 } from "../../types/agents/gemini-computer-use";
 
-export class GeminiComputerUseService extends BaseService {
-
-  /**
-   * List task jobs
-   * @param params Optional filters and pagination
-   */
-  async list(params: AgentTaskListParams = {}): Promise<AgentTaskListResponse> {
-    try {
-      return await this.request<AgentTaskListResponse>("/task/gemini-computer-use", undefined, {
-        task: params.task,
-        page: params.page,
-        limit: params.limit,
-      });
-    } catch (error) {
-      if (error instanceof HyperbrowserError) {
-        throw error;
-      }
-      throw new HyperbrowserError("Failed to list gemini-computer-use task jobs", undefined);
-    }
-  }
+export class GeminiComputerUseService extends AgentTaskListService {
+  protected readonly taskPath = "gemini-computer-use";
+  protected readonly taskLabel = "gemini-computer-use";
 
   /**
    * Start a new Gemini Computer Use task job

--- a/src/services/agents/gemini-computer-use.ts
+++ b/src/services/agents/gemini-computer-use.ts
@@ -3,6 +3,7 @@ import { BasicResponse } from "../../types";
 import { POLLING_ATTEMPTS } from "../../types/constants";
 import { sleep } from "../../utils";
 import { BaseService } from "../base";
+import { AgentTaskListParams, AgentTaskListResponse } from "../../types/agents/task";
 import {
   GeminiComputerUseTaskResponse,
   GeminiComputerUseTaskStatusResponse,
@@ -11,6 +12,26 @@ import {
 } from "../../types/agents/gemini-computer-use";
 
 export class GeminiComputerUseService extends BaseService {
+
+  /**
+   * List task jobs
+   * @param params Optional filters and pagination
+   */
+  async list(params: AgentTaskListParams = {}): Promise<AgentTaskListResponse> {
+    try {
+      return await this.request<AgentTaskListResponse>("/task/gemini-computer-use", undefined, {
+        task: params.task,
+        page: params.page,
+        limit: params.limit,
+      });
+    } catch (error) {
+      if (error instanceof HyperbrowserError) {
+        throw error;
+      }
+      throw new HyperbrowserError("Failed to list gemini-computer-use task jobs", undefined);
+    }
+  }
+
   /**
    * Start a new Gemini Computer Use task job
    * @param params The parameters for the task job

--- a/src/services/agents/hyper-agent.ts
+++ b/src/services/agents/hyper-agent.ts
@@ -2,8 +2,7 @@ import { HyperbrowserError } from "../../client";
 import { BasicResponse } from "../../types";
 import { POLLING_ATTEMPTS } from "../../types/constants";
 import { sleep } from "../../utils";
-import { BaseService } from "../base";
-import { AgentTaskListParams, AgentTaskListResponse } from "../../types/agents/task";
+import { AgentTaskListService } from "./base";
 import {
   HyperAgentTaskResponse,
   HyperAgentTaskStatusResponse,
@@ -11,26 +10,9 @@ import {
   StartHyperAgentTaskResponse,
 } from "../../types/agents/hyper-agent";
 
-export class HyperAgentService extends BaseService {
-
-  /**
-   * List task jobs
-   * @param params Optional filters and pagination
-   */
-  async list(params: AgentTaskListParams = {}): Promise<AgentTaskListResponse> {
-    try {
-      return await this.request<AgentTaskListResponse>("/task/hyper-agent", undefined, {
-        task: params.task,
-        page: params.page,
-        limit: params.limit,
-      });
-    } catch (error) {
-      if (error instanceof HyperbrowserError) {
-        throw error;
-      }
-      throw new HyperbrowserError("Failed to list hyper-agent task jobs", undefined);
-    }
-  }
+export class HyperAgentService extends AgentTaskListService {
+  protected readonly taskPath = "hyper-agent";
+  protected readonly taskLabel = "hyper-agent";
 
   /**
    * Start a new HyperAgent task job

--- a/src/services/agents/hyper-agent.ts
+++ b/src/services/agents/hyper-agent.ts
@@ -3,6 +3,7 @@ import { BasicResponse } from "../../types";
 import { POLLING_ATTEMPTS } from "../../types/constants";
 import { sleep } from "../../utils";
 import { BaseService } from "../base";
+import { AgentTaskListParams, AgentTaskListResponse } from "../../types/agents/task";
 import {
   HyperAgentTaskResponse,
   HyperAgentTaskStatusResponse,
@@ -11,6 +12,26 @@ import {
 } from "../../types/agents/hyper-agent";
 
 export class HyperAgentService extends BaseService {
+
+  /**
+   * List task jobs
+   * @param params Optional filters and pagination
+   */
+  async list(params: AgentTaskListParams = {}): Promise<AgentTaskListResponse> {
+    try {
+      return await this.request<AgentTaskListResponse>("/task/hyper-agent", undefined, {
+        task: params.task,
+        page: params.page,
+        limit: params.limit,
+      });
+    } catch (error) {
+      if (error instanceof HyperbrowserError) {
+        throw error;
+      }
+      throw new HyperbrowserError("Failed to list hyper-agent task jobs", undefined);
+    }
+  }
+
   /**
    * Start a new HyperAgent task job
    * @param params The parameters for the task job

--- a/src/services/agents/task.ts
+++ b/src/services/agents/task.ts
@@ -1,0 +1,85 @@
+import { HyperbrowserError } from "../../client";
+import { BasicResponse } from "../../types";
+import { POLLING_ATTEMPTS } from "../../types/constants";
+import {
+  StartTaskParams,
+  StartTaskResponse,
+  TaskResponse,
+  TaskStatusResponse,
+} from "../../types/agents/task";
+import { sleep } from "../../utils";
+import { BaseService } from "../base";
+
+export class TaskService extends BaseService {
+  async start(params: StartTaskParams): Promise<StartTaskResponse> {
+    try {
+      return await this.request<StartTaskResponse>("/task", {
+        method: "POST",
+        body: JSON.stringify(params),
+      });
+    } catch (error) {
+      if (error instanceof HyperbrowserError) {
+        throw error;
+      }
+      throw new HyperbrowserError("Failed to start task job", undefined);
+    }
+  }
+
+  async getStatus(id: string): Promise<TaskStatusResponse> {
+    try {
+      return await this.request<TaskStatusResponse>(`/task/${id}/status`);
+    } catch (error) {
+      if (error instanceof HyperbrowserError) {
+        throw error;
+      }
+      throw new HyperbrowserError(`Failed to get task job ${id} status`, undefined);
+    }
+  }
+
+  async get(id: string): Promise<TaskResponse> {
+    try {
+      return await this.request<TaskResponse>(`/task/${id}`);
+    } catch (error) {
+      if (error instanceof HyperbrowserError) {
+        throw error;
+      }
+      throw new HyperbrowserError(`Failed to get task job ${id}`, undefined);
+    }
+  }
+
+  async stop(id: string): Promise<BasicResponse> {
+    try {
+      return await this.request<BasicResponse>(`/task/${id}/stop`, { method: "PUT" });
+    } catch (error) {
+      if (error instanceof HyperbrowserError) {
+        throw error;
+      }
+      throw new HyperbrowserError(`Failed to stop task job ${id}`, undefined);
+    }
+  }
+
+  async startAndWait(params: StartTaskParams): Promise<TaskResponse> {
+    const jobStartResp = await this.start(params);
+    const jobId = jobStartResp.jobId;
+    if (!jobId) {
+      throw new HyperbrowserError("Failed to start task job");
+    }
+
+    let failures = 0;
+    while (true) {
+      try {
+        const jobResponse = await this.getStatus(jobId);
+        if (["completed", "failed", "stopped"].includes(jobResponse.status)) {
+          return await this.get(jobId);
+        }
+        failures = 0;
+      } catch (error) {
+        failures++;
+        if (failures >= POLLING_ATTEMPTS) {
+          throw error;
+        }
+      }
+      await sleep(1000);
+    }
+  }
+}

--- a/src/services/agents/task.ts
+++ b/src/services/agents/task.ts
@@ -76,10 +76,12 @@ export class TaskService extends BaseService {
       } catch (error) {
         failures++;
         if (failures >= POLLING_ATTEMPTS) {
-          throw error;
+          throw new HyperbrowserError(
+            `Failed to poll task job ${jobId} after ${POLLING_ATTEMPTS} attempts: ${error}`
+          );
         }
       }
-      await sleep(1000);
+      await sleep(2000);
     }
   }
 }

--- a/src/services/profiles.ts
+++ b/src/services/profiles.ts
@@ -3,6 +3,8 @@ import {
   CreateProfileParams,
   ProfileResponse,
   CreateProfileResponse,
+  UpdateProfileParams,
+  BatchDeleteProfilesParams,
   ProfileListParams,
   ProfileListResponse,
 } from "../types/profile";
@@ -57,6 +59,44 @@ export class ProfilesService extends BaseService {
         throw error;
       }
       throw new HyperbrowserError(`Failed to delete profile ${id}`, undefined);
+    }
+  }
+
+
+  /**
+   * Update an existing profile
+   * @param id The ID of the profile to update
+   * @param params Profile fields to update
+   */
+  async update(id: string, params: UpdateProfileParams): Promise<ProfileResponse> {
+    try {
+      return await this.request<ProfileResponse>(`/profile/${id}`, {
+        method: "PUT",
+        body: JSON.stringify(params),
+      });
+    } catch (error) {
+      if (error instanceof HyperbrowserError) {
+        throw error;
+      }
+      throw new HyperbrowserError(`Failed to update profile ${id}`, undefined);
+    }
+  }
+
+  /**
+   * Delete multiple profiles
+   * @param params Profile IDs to delete
+   */
+  async deleteMany(params: BatchDeleteProfilesParams): Promise<BasicResponse> {
+    try {
+      return await this.request<BasicResponse>("/profiles", {
+        method: "DELETE",
+        body: JSON.stringify(params),
+      });
+    } catch (error) {
+      if (error instanceof HyperbrowserError) {
+        throw error;
+      }
+      throw new HyperbrowserError("Failed to delete profiles", undefined);
     }
   }
 

--- a/src/services/sandboxes.ts
+++ b/src/services/sandboxes.ts
@@ -13,9 +13,17 @@ import {
   SandboxExposeResult,
   SandboxExecParams,
   SandboxExecOptions,
+  SandboxImageListParams,
   SandboxImageListResponse,
   SandboxListParams,
   SandboxListResponse,
+  SandboxRuntimeBrowserAuthResponse,
+  CreateFirecrackerImageBuildParams,
+  CompleteFirecrackerImageBuildParams,
+  CreateFirecrackerImageBuildResponse,
+  FirecrackerImageBuildResponse,
+  FirecrackerImageBuildListParams,
+  FirecrackerImageBuildListResponse,
   SandboxMemorySnapshotParams,
   SandboxMemorySnapshotResult,
   SandboxProcessResult,
@@ -484,9 +492,18 @@ export class SandboxesService extends BaseService {
     }
   }
 
-  async listImages(): Promise<SandboxImageListResponse> {
+  async listImages(params: SandboxImageListParams = {}): Promise<SandboxImageListResponse> {
     try {
-      return await this.request<SandboxImageListResponse>("/images");
+      const query = {
+        page: params.page,
+        limit: params.limit,
+        source: Array.isArray(params.source) ? params.source : params.source ? [params.source] : undefined,
+        search: params.search,
+      };
+      const hasQuery = Object.values(query).some((value) => value !== undefined);
+      return hasQuery
+        ? await this.request<SandboxImageListResponse>("/images", undefined, query)
+        : await this.request<SandboxImageListResponse>("/images");
     } catch (error) {
       if (error instanceof HyperbrowserError) {
         throw error;
@@ -502,6 +519,8 @@ export class SandboxesService extends BaseService {
       return await this.request<SandboxSnapshotListResponse>("/snapshots", undefined, {
         status: params.status,
         imageName: params.imageName,
+        search: params.search,
+        page: params.page,
         limit: params.limit,
       });
     } catch (error) {
@@ -509,6 +528,97 @@ export class SandboxesService extends BaseService {
         throw error;
       }
       throw new HyperbrowserError("Failed to list sandbox snapshots", undefined);
+    }
+  }
+
+
+  async getRuntimeBrowserAuth(
+    id: string,
+    allowedOrigin: string
+  ): Promise<SandboxRuntimeBrowserAuthResponse> {
+    try {
+      return await this.request<SandboxRuntimeBrowserAuthResponse>(`/sandbox/${id}/runtime/browser-auth`, {
+        method: "POST",
+        headers: { Origin: allowedOrigin },
+      });
+    } catch (error) {
+      if (error instanceof HyperbrowserError) {
+        throw error;
+      }
+      throw new HyperbrowserError(`Failed to issue runtime browser auth for sandbox ${id}`, undefined);
+    }
+  }
+
+  async createImageBuild(
+    params: CreateFirecrackerImageBuildParams
+  ): Promise<CreateFirecrackerImageBuildResponse> {
+    try {
+      return await this.request<CreateFirecrackerImageBuildResponse>("/images/builds", {
+        method: "POST",
+        body: JSON.stringify(params),
+      });
+    } catch (error) {
+      if (error instanceof HyperbrowserError) {
+        throw error;
+      }
+      throw new HyperbrowserError("Failed to create image build", undefined);
+    }
+  }
+
+  async listImageBuilds(
+    params: FirecrackerImageBuildListParams = {}
+  ): Promise<FirecrackerImageBuildListResponse> {
+    try {
+      return await this.request<FirecrackerImageBuildListResponse>("/images/builds", undefined, {
+        status: params.status,
+        limit: params.limit,
+      });
+    } catch (error) {
+      if (error instanceof HyperbrowserError) {
+        throw error;
+      }
+      throw new HyperbrowserError("Failed to list image builds", undefined);
+    }
+  }
+
+  async getImageBuild(buildId: string): Promise<FirecrackerImageBuildResponse> {
+    try {
+      return await this.request<FirecrackerImageBuildResponse>(`/images/builds/${buildId}`);
+    } catch (error) {
+      if (error instanceof HyperbrowserError) {
+        throw error;
+      }
+      throw new HyperbrowserError(`Failed to get image build ${buildId}`, undefined);
+    }
+  }
+
+  async completeImageBuild(
+    buildId: string,
+    params: CompleteFirecrackerImageBuildParams
+  ): Promise<FirecrackerImageBuildResponse> {
+    try {
+      return await this.request<FirecrackerImageBuildResponse>(`/images/builds/${buildId}/complete`, {
+        method: "POST",
+        body: JSON.stringify(params),
+      });
+    } catch (error) {
+      if (error instanceof HyperbrowserError) {
+        throw error;
+      }
+      throw new HyperbrowserError(`Failed to complete image build ${buildId}`, undefined);
+    }
+  }
+
+  async cancelImageBuild(buildId: string): Promise<FirecrackerImageBuildResponse> {
+    try {
+      return await this.request<FirecrackerImageBuildResponse>(`/images/builds/${buildId}/cancel`, {
+        method: "POST",
+      });
+    } catch (error) {
+      if (error instanceof HyperbrowserError) {
+        throw error;
+      }
+      throw new HyperbrowserError(`Failed to cancel image build ${buildId}`, undefined);
     }
   }
 

--- a/src/services/sessions.ts
+++ b/src/services/sessions.ts
@@ -21,6 +21,14 @@ import {
   UpdateSessionProxyParams,
   UpdateSessionScreenParams,
   SessionGetParams,
+  SessionLogsTokenResponse,
+  SessionInfoResponse,
+  SessionCreditUsageResponse,
+  SessionMetricsResponse,
+  SessionConsoleParams,
+  SessionConsoleResponse,
+  SessionNetworkParams,
+  SessionNetworkResponse,
 } from "../types/session";
 import { BaseService } from "./base";
 import { HyperbrowserError } from "../client";
@@ -327,6 +335,94 @@ export class SessionsService extends BaseService {
         throw error;
       }
       throw new HyperbrowserError("Failed to get active sessions count", undefined);
+    }
+  }
+
+
+  async stopAll(): Promise<BasicResponse> {
+    try {
+      return await this.request<BasicResponse>("/sessions/stop", { method: "PUT" });
+    } catch (error) {
+      if (error instanceof HyperbrowserError) {
+        throw error;
+      }
+      throw new HyperbrowserError("Failed to stop all sessions", undefined);
+    }
+  }
+
+  async getLogsToken(id: string): Promise<SessionLogsTokenResponse> {
+    try {
+      return await this.request<SessionLogsTokenResponse>(`/session/${id}/logs-token`);
+    } catch (error) {
+      if (error instanceof HyperbrowserError) {
+        throw error;
+      }
+      throw new HyperbrowserError(`Failed to get logs token for session ${id}`, undefined);
+    }
+  }
+
+  async getInfo(id: string): Promise<SessionInfoResponse> {
+    try {
+      return await this.request<SessionInfoResponse>(`/session/${id}/info`);
+    } catch (error) {
+      if (error instanceof HyperbrowserError) {
+        throw error;
+      }
+      throw new HyperbrowserError(`Failed to get info for session ${id}`, undefined);
+    }
+  }
+
+  async getCreditUsage(id: string): Promise<SessionCreditUsageResponse> {
+    try {
+      return await this.request<SessionCreditUsageResponse>(`/session/${id}/credit-usage`);
+    } catch (error) {
+      if (error instanceof HyperbrowserError) {
+        throw error;
+      }
+      throw new HyperbrowserError(`Failed to get credit usage for session ${id}`, undefined);
+    }
+  }
+
+  async getMetrics(id: string): Promise<SessionMetricsResponse> {
+    try {
+      return await this.request<SessionMetricsResponse>(`/session/${id}/metrics`);
+    } catch (error) {
+      if (error instanceof HyperbrowserError) {
+        throw error;
+      }
+      throw new HyperbrowserError(`Failed to get metrics for session ${id}`, undefined);
+    }
+  }
+
+  async getConsoleLogs(
+    id: string,
+    params: SessionConsoleParams = {}
+  ): Promise<SessionConsoleResponse> {
+    try {
+      return await this.request<SessionConsoleResponse>(`/session/${id}/console`, undefined, {
+        ...params,
+      });
+    } catch (error) {
+      if (error instanceof HyperbrowserError) {
+        throw error;
+      }
+      throw new HyperbrowserError(`Failed to get console logs for session ${id}`, undefined);
+    }
+  }
+
+  async getNetworkLogs(
+    id: string,
+    params: SessionNetworkParams = {}
+  ): Promise<SessionNetworkResponse> {
+    try {
+      return await this.request<SessionNetworkResponse>(`/session/${id}/network`, undefined, {
+        ...params,
+      });
+    } catch (error) {
+      if (error instanceof HyperbrowserError) {
+        throw error;
+      }
+      throw new HyperbrowserError(`Failed to get network logs for session ${id}`, undefined);
     }
   }
 

--- a/src/services/volumes.ts
+++ b/src/services/volumes.ts
@@ -1,5 +1,5 @@
 import { HyperbrowserError } from "../client";
-import { CreateVolumeParams, Volume, VolumeListResponse } from "../types/volume";
+import { CreateVolumeParams, Volume, VolumeListParams, VolumeListResponse } from "../types/volume";
 import { BaseService } from "./base";
 
 export class VolumesService extends BaseService {
@@ -23,9 +23,17 @@ export class VolumesService extends BaseService {
   /**
    * List sandbox volumes for the current team.
    */
-  async list(): Promise<VolumeListResponse> {
+  async list(params: VolumeListParams = {}): Promise<VolumeListResponse> {
     try {
-      return await this.request<VolumeListResponse>("/volume");
+      const query = {
+        page: params.page,
+        limit: params.limit,
+        search: params.search,
+      };
+      const hasQuery = Object.values(query).some((value) => value !== undefined);
+      return hasQuery
+        ? await this.request<VolumeListResponse>("/volume", undefined, query)
+        : await this.request<VolumeListResponse>("/volume");
     } catch (error) {
       if (error instanceof HyperbrowserError) {
         throw error;

--- a/src/types/agents/task.ts
+++ b/src/types/agents/task.ts
@@ -1,0 +1,69 @@
+import { TaskLlm, BrowserUseTaskStatus } from "../constants";
+import { CreateSessionParams } from "../session";
+
+export type TaskStatus = BrowserUseTaskStatus;
+
+export interface AgentTaskListParams {
+  task?: string;
+  page?: number;
+  limit?: number;
+}
+
+export interface AgentTaskSummary {
+  id: string;
+  createdAt: string;
+  status: TaskStatus;
+  task: string;
+}
+
+export interface AgentTaskListResponse {
+  tasks: AgentTaskSummary[];
+  totalCount: number;
+  page: number;
+  perPage: number;
+}
+
+export interface StartTaskParams {
+  task: string;
+  llm?: TaskLlm;
+  sessionId?: string;
+  validateOutput?: boolean;
+  useVision?: boolean;
+  useVisionForPlanner?: boolean;
+  maxActionsPerStep?: number;
+  maxInputTokens?: number;
+  plannerLlm?: TaskLlm;
+  pageExtractionLlm?: TaskLlm;
+  plannerInterval?: number;
+  maxSteps?: number;
+  keepBrowserOpen?: boolean;
+  sessionOptions?: CreateSessionParams;
+}
+
+export interface StartTaskResponse {
+  jobId: string;
+}
+
+export interface TaskMetadata {
+  inputTokens?: number | null;
+  outputTokens?: number | null;
+  numTaskStepsCompleted?: number | null;
+}
+
+export interface TaskData {
+  steps?: unknown[];
+  finalResult?: string | null;
+  [key: string]: unknown;
+}
+
+export interface TaskStatusResponse {
+  status: TaskStatus;
+}
+
+export interface TaskResponse {
+  jobId: string;
+  status: TaskStatus;
+  metadata?: TaskMetadata | null;
+  data?: TaskData | null;
+  error?: string | null;
+}

--- a/src/types/constants.ts
+++ b/src/types/constants.ts
@@ -32,15 +32,7 @@ export const POLLING_ATTEMPTS = 5;
 
 export type BrowserUseVersion = "0.1.40" | "0.7.10" | "latest";
 
-export type TaskLlm =
-  | "gpt-4o"
-  | "gpt-4o-mini"
-  | "claude-sonnet-4-5"
-  | "claude-3-7-sonnet-20250219"
-  | "claude-3-5-sonnet-20241022"
-  | "claude-3-5-haiku-20241022"
-  | "gemini-2.0-flash"
-  | "gemini-2.5-flash";
+export type TaskLlm = BrowserUseLlm;
 
 export type BrowserUseLlm =
   | "gpt-4o"

--- a/src/types/constants.ts
+++ b/src/types/constants.ts
@@ -32,6 +32,16 @@ export const POLLING_ATTEMPTS = 5;
 
 export type BrowserUseVersion = "0.1.40" | "0.7.10" | "latest";
 
+export type TaskLlm =
+  | "gpt-4o"
+  | "gpt-4o-mini"
+  | "claude-sonnet-4-5"
+  | "claude-3-7-sonnet-20250219"
+  | "claude-3-5-sonnet-20241022"
+  | "claude-3-5-haiku-20241022"
+  | "gemini-2.0-flash"
+  | "gemini-2.5-flash";
+
 export type BrowserUseLlm =
   | "gpt-4o"
   | "gpt-4o-mini"

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -15,6 +15,12 @@ export {
   ScrapeOptions,
   ScrapeJobStatusResponse,
   BatchScrapeJobStatusResponse,
+  StartBatchScrapeJobParams,
+  StartBatchScrapeJobResponse,
+  BatchScrapeJobResponse,
+  GetBatchScrapeJobParams,
+  ScrapedPage,
+  ScreenshotOptions,
   StorageStateOptions,
 } from "./scrape";
 export {
@@ -92,6 +98,18 @@ export {
   GeminiComputerUseTaskMetadata,
 } from "./agents/gemini-computer-use";
 export {
+  TaskStatus,
+  TaskMetadata,
+  TaskData,
+  StartTaskParams,
+  StartTaskResponse,
+  TaskStatusResponse,
+  TaskResponse,
+  AgentTaskListParams,
+  AgentTaskSummary,
+  AgentTaskListResponse,
+} from "./agents/task";
+export {
   BasicResponse,
   SessionStatus,
   Session,
@@ -114,6 +132,19 @@ export {
   SessionProfile,
   SessionLaunchState,
   SessionCreditBreakdown,
+  SessionRecording,
+  CreateSessionProfile,
+  SessionLogsTokenResponse,
+  SessionInfoResponse,
+  SessionCreditUsageResponse,
+  SessionMetricsResponse,
+  SessionLogLevel,
+  SessionLogOrder,
+  SessionNetworkMethod,
+  SessionConsoleParams,
+  SessionConsoleResponse,
+  SessionNetworkParams,
+  SessionNetworkResponse,
   UpdateSessionProfileParams,
   UpdateSessionProxyLocationParams,
   UpdateSessionProxyParams,
@@ -128,13 +159,26 @@ export {
   SandboxVolumeMount,
   SandboxListParams,
   SandboxListResponse,
+  SandboxImageSource,
   SandboxImageSummary,
+  SandboxImageListParams,
   SandboxImageListResponse,
   SandboxSnapshotStatus,
   SandboxSnapshotSummary,
   SandboxSnapshotListParams,
   SandboxSnapshotListResponse,
   CreateSandboxParams,
+  SandboxRuntimeBrowserAuthResponse,
+  FirecrackerImageBuildStatus,
+  FirecrackerImageInit,
+  CreateFirecrackerImageBuildParams,
+  CompleteFirecrackerImageBuildParams,
+  FirecrackerImageBuild,
+  FirecrackerImageBuildUpload,
+  CreateFirecrackerImageBuildResponse,
+  FirecrackerImageBuildResponse,
+  FirecrackerImageBuildListParams,
+  FirecrackerImageBuildListResponse,
   SandboxMemorySnapshotParams,
   SandboxMemorySnapshotResult,
   SandboxExposeParams,
@@ -178,11 +222,13 @@ export {
   SandboxTerminalKillParams,
   SandboxTerminalEvent,
 } from "./sandbox";
-export { CreateVolumeParams, Volume, VolumeListResponse } from "./volume";
+export { CreateVolumeParams, Volume, VolumeListParams, VolumeListResponse } from "./volume";
 export {
   CreateProfileParams,
   ProfileResponse,
   CreateProfileResponse,
+  UpdateProfileParams,
+  BatchDeleteProfilesParams,
   ProfileListParams,
   ProfileListResponse,
 } from "./profile";
@@ -220,6 +266,7 @@ export {
   SessionEventLogType,
   SessionRegion,
   BrowserUseVersion,
+  TaskLlm,
   HyperAgentVersion,
 } from "./constants";
 export { TeamCreditInfo } from "./team";
@@ -256,6 +303,15 @@ export {
   BatchFetchJobResponse,
   BatchFetchJobStatus,
 } from "./web/batch-fetch";
+export {
+  StartWebCrawlJobParams,
+  GetWebCrawlJobParams,
+  StartWebCrawlJobResponse,
+  WebCrawlJobStatusResponse,
+  WebCrawlJobResponse,
+  WebCrawlJobStatus,
+  WebCrawlOptions,
+} from "./web/crawl";
 export {
   WebSearchParams,
   WebSearchResponse,

--- a/src/types/profile.ts
+++ b/src/types/profile.ts
@@ -2,6 +2,14 @@ export interface CreateProfileParams {
   name?: string;
 }
 
+export interface UpdateProfileParams {
+  name?: string;
+}
+
+export interface BatchDeleteProfilesParams {
+  ids: string[];
+}
+
 export interface CreateProfileResponse {
   id: string;
   name: string | null;

--- a/src/types/sandbox.ts
+++ b/src/types/sandbox.ts
@@ -103,12 +103,20 @@ export interface SandboxImageSummary {
   updatedAt: string;
 }
 
+export type SandboxImageSource = "public" | "team";
+
+export interface SandboxImageListParams {
+  page?: number;
+  limit?: number;
+  source?: SandboxImageSource | SandboxImageSource[];
+  search?: string;
+}
+
 export interface SandboxImageListResponse {
   images: SandboxImageSummary[];
-  // TODO: add pagination metadata when /api/images supports it.
-  // totalCount?: number;
-  // page?: number;
-  // perPage?: number;
+  totalCount: number;
+  page: number;
+  perPage: number;
 }
 
 export type SandboxSnapshotStatus = "creating" | "created" | "failed";
@@ -129,17 +137,108 @@ export interface SandboxSnapshotSummary {
 }
 
 export interface SandboxSnapshotListParams {
-  status?: SandboxSnapshotStatus;
+  status?: SandboxSnapshotStatus | SandboxSnapshotStatus[];
   imageName?: string;
+  search?: string;
+  page?: number;
   limit?: number;
 }
 
 export interface SandboxSnapshotListResponse {
   snapshots: SandboxSnapshotSummary[];
-  // TODO: add pagination metadata when /api/snapshots supports it.
-  // totalCount?: number;
-  // page?: number;
-  // perPage?: number;
+  totalCount: number;
+  page: number;
+  perPage: number;
+}
+
+
+export interface SandboxRuntimeBrowserAuthResponse {
+  runtime: SandboxRuntimeTarget;
+  allowedOrigin: string;
+  capabilities: string[];
+  bootstrapUrl: string;
+  bootstrapUrlExpiresAt: string | null;
+}
+
+export type FirecrackerImageBuildStatus =
+  | "awaiting_upload"
+  | "upload_verified"
+  | "dispatching"
+  | "building"
+  | "verifying"
+  | "completed"
+  | "failed"
+  | "canceled";
+
+export interface FirecrackerImageInit {
+  commands?: string[];
+  [key: string]: unknown;
+}
+
+export interface CreateFirecrackerImageBuildParams {
+  imageName: string;
+  inputSha256: string;
+  inputSizeBytes: number;
+  inputFormat: string;
+  sourcePlatform: string;
+  imageConfigUser?: string;
+  imageInit?: FirecrackerImageInit;
+}
+
+export interface CompleteFirecrackerImageBuildParams {
+  inputSha256: string;
+  inputSizeBytes: number;
+  inputFormat: string;
+}
+
+export interface FirecrackerImageBuild {
+  id: string;
+  teamId: string;
+  userId: string | null;
+  namespace: string;
+  imageName: string;
+  imageId: string;
+  status: FirecrackerImageBuildStatus;
+  inputBucket?: string | null;
+  inputKey?: string | null;
+  inputSha256?: string | null;
+  inputSizeBytes?: number | null;
+  outputBucket?: string | null;
+  outputKey?: string | null;
+  vmId?: string | null;
+  errorCode?: string | null;
+  errorMessage?: string | null;
+  metadata?: Record<string, unknown> | null;
+  completedAt?: string | null;
+  createdAt: string;
+  updatedAt: string;
+}
+
+export interface FirecrackerImageBuildUpload {
+  url: string;
+  method: "PUT";
+  headers: Record<string, string>;
+  objectKey: string;
+  expiresInSeconds: number;
+  maxUploadBytes: number;
+}
+
+export interface CreateFirecrackerImageBuildResponse {
+  build: FirecrackerImageBuild;
+  upload: FirecrackerImageBuildUpload;
+}
+
+export interface FirecrackerImageBuildResponse {
+  build: FirecrackerImageBuild;
+}
+
+export interface FirecrackerImageBuildListParams {
+  status?: FirecrackerImageBuildStatus;
+  limit?: number;
+}
+
+export interface FirecrackerImageBuildListResponse {
+  builds: FirecrackerImageBuild[];
 }
 
 export interface SandboxMemorySnapshotParams {

--- a/src/types/session.ts
+++ b/src/types/session.ts
@@ -244,3 +244,76 @@ export interface UpdateSessionScreenParams {
   width: number;
   height: number;
 }
+
+
+export interface SessionLogsTokenResponse {
+  token: string;
+  tokenExpiresAt: string;
+}
+
+export interface SessionInfoProfile {
+  id: string;
+  name?: string | null;
+}
+
+export interface SessionInfoResponse {
+  id: string;
+  status: SessionStatus;
+  startTime?: number | null;
+  launchState?: SessionLaunchState | null;
+  duration: number;
+  proxyBytesUsed: number;
+  region: string;
+  settings: unknown[];
+  recordingUrl?: string | null;
+  videoRecordingUrl?: string | null;
+  videoRecordingPlaylistUrl?: string | null;
+  isRecordingEncrypted?: boolean | null;
+  liveUrl?: string | null;
+  liveDomain?: string | null;
+  profile?: SessionInfoProfile | null;
+  creditsUsed?: number | null;
+  creditBreakdown?: SessionCreditBreakdown | null;
+}
+
+export interface SessionCreditUsageResponse {
+  creditUsage: number | null;
+}
+
+export interface SessionMetricsResponse {
+  metrics: Array<Record<string, unknown>>;
+  displayedMetrics: string[];
+}
+
+export type SessionLogLevel = "log" | "debug" | "info" | "error" | "warning";
+export type SessionLogOrder = "asc" | "desc";
+export type SessionNetworkMethod = "GET" | "POST" | "PUT" | "DELETE" | "PATCH" | "OPTIONS" | "HEAD";
+
+export interface SessionConsoleParams {
+  logLevels?: SessionLogLevel[];
+  search?: string;
+  afterTimestamp?: number;
+  beforeTimestamp?: number;
+  order?: SessionLogOrder;
+  limit?: number;
+}
+
+export interface SessionNetworkParams {
+  methods?: SessionNetworkMethod[];
+  statusCodes?: string[];
+  search?: string;
+  afterTimestamp?: number;
+  beforeTimestamp?: number;
+  order?: SessionLogOrder;
+  limit?: number;
+}
+
+export interface SessionConsoleResponse {
+  consoleLogs: Array<Record<string, unknown>>;
+  pages: Array<Record<string, unknown>>;
+}
+
+export interface SessionNetworkResponse {
+  networkCalls: Array<Record<string, unknown>>;
+  pages: Array<Record<string, unknown>>;
+}

--- a/src/types/volume.ts
+++ b/src/types/volume.ts
@@ -9,6 +9,15 @@ export interface Volume {
   transferAmount?: number;
 }
 
+export interface VolumeListParams {
+  page?: number;
+  limit?: number;
+  search?: string;
+}
+
 export interface VolumeListResponse {
   volumes: Volume[];
+  totalCount: number;
+  page: number;
+  perPage: number;
 }


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
- Add SDK wrappers for profile update/batch delete, task listing and generic tasks, session utility endpoints, volume pagination, sandbox runtime browser auth, and image build APIs.
- Export missing public types for batch scrape, web crawl, sessions, volumes, profiles, tasks, and sandbox image/build APIs.
- Address Bugbot feedback by matching generic task polling to existing agent services and extracting shared agent task-list logic.

## Validation
- `yarn build`
- `yarn lint`
- `npx vitest run tests/sandbox/e2e/list-contract.test.ts tests/sandbox/e2e/volumes-contract.test.ts tests/integration/client-http.test.ts`
- `yarn test` currently reaches environment-dependent sandbox e2e calls and fails with `ECONNREFUSED` to `http://localhost:8080/api/sandbox`; contract/integration tests pass.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-92d5ff6c-15c2-4ab7-8fb1-d9205121b9e9"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-92d5ff6c-15c2-4ab7-8fb1-d9205121b9e9"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

