### PR TITLE
Change runner version

### DIFF
--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -1,8 +1,6 @@
 name: Integration Tests
 
 on:
-  pull_request:
-    branches: [main]
   merge_group:
     types: [checks_requested]
   workflow_dispatch:

--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -16,7 +16,7 @@ permissions:
 
 jobs:
   integration-tests:
-    runs-on: ubuntu-slim
+    runs-on: ubuntu-24.04
 
     steps:
       - name: Check out repository


### PR DESCRIPTION

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/hyperbrowserai/node-sdk/pull/85" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> CI-only change limited to workflow triggers and runner image; main risk is reduced PR signal or environment differences causing unexpected CI behavior.
> 
> **Overview**
> Updates the `Integration Tests` GitHub Actions workflow to run on `ubuntu-24.04` instead of `ubuntu-slim`.
> 
> Removes the `pull_request` trigger (previously limited to `main`), leaving the workflow to run only via `merge_group` and manual `workflow_dispatch`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 64af09dac4430072fa257d9681bec84b7630442c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->