### PR TITLE
Add fake int test

### DIFF
--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -1,6 +1,8 @@
 name: Integration Tests
 
 on:
+  pull_request:
+    branches: [main]
   merge_group:
     types: [checks_requested]
   workflow_dispatch:
@@ -14,33 +16,45 @@ permissions:
 
 jobs:
   integration-tests:
+    name: integration-tests
     runs-on: ubuntu-24.04
 
     steps:
+      - name: PR placeholder
+        if: github.event_name == 'pull_request'
+        run: echo "Integration tests run only in the merge queue."
+
       - name: Check out repository
+        if: github.event_name == 'merge_group' || github.event_name == 'workflow_dispatch'
         uses: actions/checkout@v5
 
       - name: Set up Node.js
+        if: github.event_name == 'merge_group' || github.event_name == 'workflow_dispatch'
         uses: actions/setup-node@v6
         with:
           node-version: 22.22.1
           cache: yarn
 
       - name: Set up Yarn
+        if: github.event_name == 'merge_group' || github.event_name == 'workflow_dispatch'
         run: |
           corepack enable
           corepack prepare yarn@1.22.22 --activate
 
       - name: Show tool versions
+        if: github.event_name == 'merge_group' || github.event_name == 'workflow_dispatch'
         run: |
           node --version
           yarn --version
 
       - name: Install dependencies
+        if: github.event_name == 'merge_group' || github.event_name == 'workflow_dispatch'
         run: yarn install --frozen-lockfile
 
       - name: Build package
+        if: github.event_name == 'merge_group' || github.event_name == 'workflow_dispatch'
         run: yarn build
 
       - name: Run integration tests
+        if: github.event_name == 'merge_group' || github.event_name == 'workflow_dispatch'
         run: yarn test:integration


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Workflow-only changes that gate when CI runs; risk is limited to potentially missing integration coverage on PRs if merge queue isn’t used as intended.
> 
> **Overview**
> Updates the `Integration Tests` GitHub Actions workflow to also trigger on `pull_request` to `main`, but **skips the actual install/build/test steps on PRs**.
> 
> On PR events it now runs a placeholder step that prints a message, while the real integration test job continues to run only for `merge_group` (merge queue) and `workflow_dispatch` events via per-step `if` conditions.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 96b1773ceeaeb9ae7a27aae8268ddf1fbf43b275. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->