### PR TITLE
Captcha manual solve

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hyperbrowser/sdk",
-  "version": "0.89.9",
+  "version": "0.90.0",
   "description": "Node SDK for Hyperbrowser API",
   "author": "",
   "repository": {

--- a/src/services/base.ts
+++ b/src/services/base.ts
@@ -62,9 +62,11 @@ export class BaseService {
         (key) => key.toLowerCase() === "content-type"
       ) as keyof HeadersInit;
 
+      const requestTimeout = init?.timeout ?? this.timeout;
+
       const response = await fetch(url.toString(), {
         ...init,
-        timeout: this.timeout,
+        timeout: requestTimeout,
         headers: {
           "x-api-key": this.apiKey,
           ...(contentTypeKey && init?.headers

--- a/src/services/sessions.ts
+++ b/src/services/sessions.ts
@@ -4,6 +4,8 @@ import FormData from "form-data";
 import { RequestInit } from "node-fetch";
 import {
   BasicResponse,
+  CaptchaEvaluationParams,
+  CaptchaEvaluationResponse,
   CreateSessionParams,
   GetActiveSessionsCountResponse,
   GetSessionDownloadsUrlResponse,
@@ -20,10 +22,14 @@ import {
   UpdateSessionProfileParams,
   UpdateSessionProxyParams,
   UpdateSessionScreenParams,
+  UpdateSessionSolveCaptchasParams,
+  UpdateSessionSolveCaptchasResponse,
   SessionGetParams,
 } from "../types/session";
 import { BaseService } from "./base";
 import { HyperbrowserError } from "../client";
+
+const CAPTCHA_EVALUATION_REQUEST_TIMEOUT_MS = 185_000;
 
 /**
  * Service for managing session event logs
@@ -113,6 +119,29 @@ export class SessionsService extends BaseService {
         throw error;
       }
       throw new HyperbrowserError(`Failed to stop session ${id}`, undefined);
+    }
+  }
+
+  /**
+   * Manually evaluate captchas in a running session.
+   * @param id The ID of the session to evaluate
+   * @param params Optional captcha evaluation parameters
+   */
+  async evaluateCaptcha(
+    id: string,
+    params: CaptchaEvaluationParams = {}
+  ): Promise<CaptchaEvaluationResponse> {
+    try {
+      return await this.request<CaptchaEvaluationResponse>(`/session/${id}/captcha/evaluate`, {
+        method: "POST",
+        timeout: Math.max(this.timeout, CAPTCHA_EVALUATION_REQUEST_TIMEOUT_MS),
+        body: JSON.stringify(params),
+      });
+    } catch (error) {
+      if (error instanceof HyperbrowserError) {
+        throw error;
+      }
+      throw new HyperbrowserError(`Failed to evaluate captcha for session ${id}`, undefined);
     }
   }
 
@@ -409,6 +438,57 @@ export class SessionsService extends BaseService {
         throw error;
       }
       throw new HyperbrowserError(`Failed to update screen for session ${id}`, undefined);
+    }
+  }
+
+  /**
+   * Start automatic captcha solving for a running session.
+   * @param id The ID of the session to update
+   * @param params Optional captcha solver parameters
+   */
+  async startCaptchaSolving(
+    id: string,
+    params: UpdateSessionSolveCaptchasParams = {}
+  ): Promise<UpdateSessionSolveCaptchasResponse> {
+    try {
+      return await this.request<UpdateSessionSolveCaptchasResponse>(`/session/${id}/update`, {
+        method: "PUT",
+        body: JSON.stringify({
+          type: "solveCaptchas",
+          params: {
+            enabled: true,
+            ...params,
+          },
+        }),
+      });
+    } catch (error) {
+      if (error instanceof HyperbrowserError) {
+        throw error;
+      }
+      throw new HyperbrowserError(`Failed to start captcha solving for session ${id}`, undefined);
+    }
+  }
+
+  /**
+   * Stop automatic captcha solving for a running session.
+   * @param id The ID of the session to update
+   */
+  async stopCaptchaSolving(id: string): Promise<UpdateSessionSolveCaptchasResponse> {
+    try {
+      return await this.request<UpdateSessionSolveCaptchasResponse>(`/session/${id}/update`, {
+        method: "PUT",
+        body: JSON.stringify({
+          type: "solveCaptchas",
+          params: {
+            enabled: false,
+          },
+        }),
+      });
+    } catch (error) {
+      if (error instanceof HyperbrowserError) {
+        throw error;
+      }
+      throw new HyperbrowserError(`Failed to stop captcha solving for session ${id}`, undefined);
     }
   }
 

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -100,6 +100,12 @@ export {
   SessionListParams,
   SessionListResponse,
   ScreenConfig,
+  CaptchaEvaluationPageResult,
+  CaptchaEvaluationParams,
+  CaptchaEvaluationResponse,
+  CaptchaEvaluationTarget,
+  CaptchaEvaluationType,
+  CaptchaSolverType,
   CreateSessionParams,
   GetSessionDownloadsUrlResponse,
   GetSessionVideoRecordingUrlResponse,
@@ -118,6 +124,8 @@ export {
   UpdateSessionProxyLocationParams,
   UpdateSessionProxyParams,
   UpdateSessionScreenParams,
+  UpdateSessionSolveCaptchasParams,
+  UpdateSessionSolveCaptchasResponse,
 } from "./session";
 export {
   SandboxStatus,

--- a/src/types/session.ts
+++ b/src/types/session.ts
@@ -35,6 +35,7 @@ export interface SessionLaunchState {
   enableVideoWebRecording?: boolean;
   enableLogCapture?: boolean;
   acceptCookies?: boolean;
+  solverType?: CaptchaSolverType;
   profile?: SessionProfile;
   staticIpId?: string;
   saveDownloads?: boolean;
@@ -109,6 +110,55 @@ export interface ImageCaptchaParam {
   inputSelector: string;
 }
 
+export type CaptchaSolverType = "visual" | (string & {});
+
+export type CaptchaEvaluationType =
+  | "turnstile"
+  | "cloudflare-challenge"
+  | "aliexpress"
+  | "recaptcha"
+  | "recaptcha-visual"
+  | "amazon"
+  | "datadome"
+  | "normal";
+
+export type CaptchaEvaluationTarget =
+  | CaptchaEvaluationType
+  | (string & {});
+
+export interface CaptchaEvaluationParams {
+  captcha?: CaptchaEvaluationTarget;
+  captchaType?: CaptchaEvaluationTarget;
+  text?: CaptchaEvaluationTarget;
+  iterations?: number;
+  maxIterations?: number;
+  solverType?: CaptchaSolverType;
+  imageCaptchaParams?: Array<ImageCaptchaParam>;
+  useGeminiCaptchaSolver?: boolean;
+  useUltraStealth?: boolean;
+}
+
+export interface CaptchaEvaluationPageResult {
+  url: string;
+  targetId: string | null;
+  iterationsRun: number;
+  solved: boolean;
+  solvedCaptchas: CaptchaEvaluationType[];
+  checkedCaptchas: CaptchaEvaluationType[];
+  captchaSolvedCounts: Record<string, number>;
+  lastSolveTime: Record<string, number>;
+}
+
+export interface CaptchaEvaluationResponse {
+  success: true;
+  captcha: CaptchaEvaluationType | null;
+  iterationsRequested: number;
+  iterationsRun: number;
+  solved: boolean;
+  solvedCaptchas: CaptchaEvaluationType[];
+  pages: CaptchaEvaluationPageResult[];
+}
+
 export interface CreateSessionParams {
   useUltraStealth?: boolean;
   useStealth?: boolean;
@@ -125,6 +175,7 @@ export interface CreateSessionParams {
   locales?: ISO639_1[];
   screen?: ScreenConfig;
   solveCaptchas?: boolean;
+  solverType?: CaptchaSolverType;
   adblock?: boolean;
   trackers?: boolean;
   annoyances?: boolean;
@@ -243,4 +294,14 @@ export interface UpdateSessionProxyParams {
 export interface UpdateSessionScreenParams {
   width: number;
   height: number;
+}
+
+export interface UpdateSessionSolveCaptchasParams {
+  solverType?: CaptchaSolverType;
+}
+
+export interface UpdateSessionSolveCaptchasResponse extends BasicResponse {
+  solveCaptchas?: boolean;
+  sessionId?: string;
+  telemetryReady?: boolean;
 }

--- a/src/types/session.ts
+++ b/src/types/session.ts
@@ -118,13 +118,9 @@ export type CaptchaEvaluationType =
   | "aliexpress"
   | "recaptcha"
   | "recaptcha-visual"
-  | "amazon"
-  | "datadome"
-  | "normal";
+  | "amazon";
 
-export type CaptchaEvaluationTarget =
-  | CaptchaEvaluationType
-  | (string & {});
+export type CaptchaEvaluationTarget = CaptchaEvaluationType;
 
 export interface CaptchaEvaluationParams {
   captcha?: CaptchaEvaluationTarget;

--- a/tests/integration/client-http.test.ts
+++ b/tests/integration/client-http.test.ts
@@ -60,6 +60,49 @@ const startServer = async (): Promise<TestServer> => {
       return;
     }
 
+    if (
+      request.method === "POST" &&
+      request.url ===
+        "/api/session/52dd29fb-75a2-43f9-9831-8ff377fedb0a/captcha/evaluate"
+    ) {
+      await new Promise((resolve) => setTimeout(resolve, 10));
+      sendJson(response, 200, {
+        success: true,
+        captcha: "recaptcha-visual",
+        iterationsRequested: 5,
+        iterationsRun: 1,
+        solved: true,
+        solvedCaptchas: ["recaptcha-visual"],
+        pages: [
+          {
+            url: "https://example.com",
+            targetId: "target_123",
+            iterationsRun: 1,
+            solved: true,
+            solvedCaptchas: ["recaptcha-visual"],
+            checkedCaptchas: ["recaptcha-visual"],
+            captchaSolvedCounts: { "recaptcha-visual": 1 },
+            lastSolveTime: { "recaptcha-visual": 123 },
+          },
+        ],
+      });
+      return;
+    }
+
+    if (
+      request.method === "PUT" &&
+      request.url === "/api/session/52dd29fb-75a2-43f9-9831-8ff377fedb0a/update"
+    ) {
+      const updateBody = body as { type?: string; params?: { enabled?: boolean } };
+      if (updateBody.type === "solveCaptchas") {
+        sendJson(response, 200, {
+          success: true,
+          solveCaptchas: Boolean(updateBody.params?.enabled),
+        });
+        return;
+      }
+    }
+
     sendJson(response, 404, { message: `unexpected route ${request.method} ${request.url}` });
   });
 
@@ -130,6 +173,106 @@ describe("client HTTP integration", () => {
         apiKey: "test-api-key",
         contentType: "application/json",
         body: undefined,
+      },
+    ]);
+  });
+
+  test("session captcha evaluation posts the requested captcha target and iterations", async () => {
+    const server = await startServer();
+    servers.push(server);
+    const client = new HyperbrowserClient({
+      apiKey: "test-api-key",
+      baseUrl: server.baseUrl,
+      timeout: 1,
+    });
+
+    const result = await client.sessions.evaluateCaptcha(
+      "52dd29fb-75a2-43f9-9831-8ff377fedb0a",
+      {
+        captcha: "recaptcha-visual",
+        iterations: 5,
+      }
+    );
+
+    expect(result).toEqual({
+      success: true,
+      captcha: "recaptcha-visual",
+      iterationsRequested: 5,
+      iterationsRun: 1,
+      solved: true,
+      solvedCaptchas: ["recaptcha-visual"],
+      pages: [
+        {
+          url: "https://example.com",
+          targetId: "target_123",
+          iterationsRun: 1,
+          solved: true,
+          solvedCaptchas: ["recaptcha-visual"],
+          checkedCaptchas: ["recaptcha-visual"],
+          captchaSolvedCounts: { "recaptcha-visual": 1 },
+          lastSolveTime: { "recaptcha-visual": 123 },
+        },
+      ],
+    });
+    expect(server.requests).toEqual([
+      {
+        method: "POST",
+        url: "/api/session/52dd29fb-75a2-43f9-9831-8ff377fedb0a/captcha/evaluate",
+        apiKey: "test-api-key",
+        contentType: "application/json",
+        body: {
+          captcha: "recaptcha-visual",
+          iterations: 5,
+        },
+      },
+    ]);
+  });
+
+  test("session captcha solving update starts and stops automatic solving", async () => {
+    const server = await startServer();
+    servers.push(server);
+    const client = new HyperbrowserClient({
+      apiKey: "test-api-key",
+      baseUrl: server.baseUrl,
+    });
+
+    const started = await client.sessions.startCaptchaSolving(
+      "52dd29fb-75a2-43f9-9831-8ff377fedb0a",
+      {
+        solverType: "visual",
+      }
+    );
+    const stopped = await client.sessions.stopCaptchaSolving(
+      "52dd29fb-75a2-43f9-9831-8ff377fedb0a"
+    );
+
+    expect(started).toEqual({ success: true, solveCaptchas: true });
+    expect(stopped).toEqual({ success: true, solveCaptchas: false });
+    expect(server.requests).toEqual([
+      {
+        method: "PUT",
+        url: "/api/session/52dd29fb-75a2-43f9-9831-8ff377fedb0a/update",
+        apiKey: "test-api-key",
+        contentType: "application/json",
+        body: {
+          type: "solveCaptchas",
+          params: {
+            enabled: true,
+            solverType: "visual",
+          },
+        },
+      },
+      {
+        method: "PUT",
+        url: "/api/session/52dd29fb-75a2-43f9-9831-8ff377fedb0a/update",
+        apiKey: "test-api-key",
+        contentType: "application/json",
+        body: {
+          type: "solveCaptchas",
+          params: {
+            enabled: false,
+          },
+        },
       },
     ]);
   });


### PR DESCRIPTION
## Summary
Add manual solving to sdk

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Adds new session APIs for captcha evaluation/solver toggling and changes request timeout handling to allow per-request overrides; mistakes could cause unexpected long-running requests or behavior differences for callers relying on the global timeout.
> 
> **Overview**
> Bumps the SDK version to `0.90.0` and adds session-level captcha capabilities.
> 
> `SessionsService` now supports manual captcha evaluation via `POST /session/:id/captcha/evaluate` (with new request/response types and a longer minimum timeout) and exposes `startCaptchaSolving`/`stopCaptchaSolving` helpers that toggle captcha solving through the existing `/session/:id/update` endpoint.
> 
> `BaseService.request` is updated to respect an optional per-request `timeout` instead of always using the client default, and new integration tests cover the captcha evaluation and solver start/stop request payloads.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 07391e6a41cf78ed50e58485207351cd5d7aa54f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->