### PR TITLE
feat: add Claude Opus 4.8 to ClaudeComputerUseLlm type

### DIFF
--- a/src/types/constants.ts
+++ b/src/types/constants.ts
@@ -52,6 +52,7 @@ export type ClaudeComputerUseLlm =
   | "claude-opus-4-5"
   | "claude-opus-4-6"
   | "claude-opus-4-7"
+  | "claude-opus-4-8"
   | "claude-haiku-4-5-20251001"
   | "claude-sonnet-4-5"
   | "claude-sonnet-4-6"


### PR DESCRIPTION
## Summary

Adds `"claude-opus-4-8"` to the `ClaudeComputerUseLlm` type union in `src/types/constants.ts`.