### PR TITLE
[codex] Add active session profile fork parameter

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hyperbrowser/sdk",
-  "version": "0.91.0",
+  "version": "0.91.1",
   "description": "Node SDK for Hyperbrowser API",
   "author": "",
   "repository": {

--- a/src/types/session.ts
+++ b/src/types/session.ts
@@ -292,6 +292,7 @@ export interface SessionEventLogListResponse {
 export interface UpdateSessionProfileParams {
   persistChanges?: boolean;
   persistNetworkCache?: boolean;
+  forkToProfileId?: string;
 }
 
 export interface UpdateSessionProxyLocationParams {


### PR DESCRIPTION
## Summary

- Adds `forkToProfileId` to `UpdateSessionProfileParams` so callers can request active-session profile forking.
- Bumps the Node SDK version from `0.91.0` to `0.91.1`.

## Validation

- `yarn build`
- `yarn lint`

Created via Codex after rebasing onto current `origin/main`.