### PR TITLE
add gemini-3.5-flash to gemini computer use

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hyperbrowser/sdk",
-  "version": "0.91.0",
+  "version": "0.91.1",
   "description": "Node SDK for Hyperbrowser API",
   "author": "",
   "repository": {

--- a/src/types/constants.ts
+++ b/src/types/constants.ts
@@ -80,6 +80,7 @@ export type HyperAgentLlm =
   | "gemini-3-flash-preview";
 
 export type GeminiComputerUseLlm =
+  | "gemini-3.5-flash"
   | "gemini-3-flash-preview"
   | "gemini-2.5-computer-use-preview-10-2025";
 


### PR DESCRIPTION
## Summary
<!-- 1-2 sentences: what changed and why. -->

## Changes
<!-- Bullet list of the concrete changes. Keep it short. -->
- 
- 

## Validation
<!-- Commands you ran. Mention any manual testing. -->
- `yarn lint`
- `yarn build`

<!-- Closes #123 -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> SDK-only type and version bump with no runtime logic changes; risk is limited to consumers relying on the expanded LLM union matching the API.
> 
> **Overview**
> Adds **`gemini-3.5-flash`** as a selectable model on the **`GeminiComputerUseLlm`** union in `src/types/constants.ts`, so Gemini computer-use tasks can type-check when passing that `llm` value (e.g. on `StartGeminiComputerUseTaskParams`).
> 
> Bumps the package version from **0.91.0** to **0.91.1** for release.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 7dd15aa7de2825f835cce31d90d16a0df273336d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->