### PR TITLE
add browsery memory size

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hyperbrowser/sdk",
-  "version": "0.91.1",
+  "version": "0.91.2",
   "description": "Node SDK for Hyperbrowser API",
   "author": "",
   "repository": {

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -93,6 +93,7 @@ export {
 } from "./agents/gemini-computer-use";
 export {
   BasicResponse,
+  BrowserMemorySize,
   SessionStatus,
   Session,
   SessionDetail,

--- a/src/types/session.ts
+++ b/src/types/session.ts
@@ -12,6 +12,7 @@ import {
 } from "./constants";
 
 export type SessionStatus = "active" | "closed" | "error";
+export type BrowserMemorySize = "small" | "medium" | "large";
 
 export interface BasicResponse {
   success: boolean;
@@ -206,6 +207,7 @@ export interface CreateSessionParams {
   liveViewTtlSeconds?: number;
   replaceNativeElements?: boolean;
   disablePostQuantumKeyAgreement?: boolean;
+  browserMemorySize?: BrowserMemorySize;
   startFromSnapshot?: StartSessionFromSnapshotParams;
 }
 


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Type-only SDK change with no runtime logic; consumers opt in via an optional field on session create.
> 
> **Overview**
> Adds optional **`browserMemorySize`** on **`CreateSessionParams`** so callers can choose browser RAM tier (`small` | `medium` | `large`) when creating a session. The new **`BrowserMemorySize`** type is defined in `session.ts` and re-exported from the package types entrypoint.
> 
> Bumps **`@hyperbrowser/sdk`** to **0.91.2** (patch release).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d1a21d28f6f739cc26b12313cf565256bffb9147. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->