### PR TITLE
Add GPT 5.6 agent model support

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hyperbrowser/sdk",
-  "version": "0.91.3",
+  "version": "0.91.4",
   "description": "Node SDK for Hyperbrowser API",
   "author": "",
   "repository": {

--- a/src/types/constants.ts
+++ b/src/types/constants.ts
@@ -61,11 +61,19 @@ export type ClaudeComputerUseLlm =
   | "claude-sonnet-4-20250514"
   | "claude-3-7-sonnet-20250219";
 
-export type CuaLlm = "computer-use-preview" | "gpt-5.4" | "gpt-5.4-mini" | "gpt-5.5";
+export type CuaLlm =
+  | "computer-use-preview"
+  | "gpt-5.6-sol"
+  | "gpt-5.6-terra"
+  | "gpt-5.6-luna"
+  | "gpt-5.5"
+  | "gpt-5.4"
+  | "gpt-5.4-mini";
 
 export type HyperAgentVersion = "0.8.0" | "1.1.0";
 
 export type HyperAgentLlm =
+  | "gpt-5.6-luna"
   | "gpt-5.5"
   | "gpt-5.2"
   | "gpt-5.1"


### PR DESCRIPTION
## Summary
Adds Node SDK model literals for the GPT-5.6 models introduced in [browserctrl#1211](https://github.com/hyperbrowserai/browserctrl/pull/1211), while limiting HyperAgent support to Luna.

## Changes
- Add `gpt-5.6-sol`, `gpt-5.6-terra`, and `gpt-5.6-luna` to `CuaLlm`
- Add `gpt-5.6-luna` to `HyperAgentLlm`
- Bump the package version to `0.91.4`

## Validation
- `yarn lint`
- `yarn build`

Link to Devin session: https://app.devin.ai/sessions/f284337c4bc9449da73ead049ff14a40
Requested by: @shrisukhani

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Additive TypeScript string-literal unions and a patch version bump only; no runtime or API client logic changes.
> 
> **Overview**
> Extends the Node SDK type definitions so clients can pass **GPT-5.6** model IDs when starting agent tasks, aligned with backend support from browserctrl#1211.
> 
> **CUA (`CuaLlm`)** now includes `gpt-5.6-sol`, `gpt-5.6-terra`, and `gpt-5.6-luna` (existing GPT-5.x entries are unchanged; the union is reformatted for readability). **HyperAgent (`HyperAgentLlm`)** adds only **`gpt-5.6-luna`**, so Sol/Terra are CUA-only in this SDK surface.
> 
> Package version is bumped to **`0.91.4`** for release.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f62a264e456431d51b1539c24845f0de5b5c7cf4. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->