### PR TITLE
feat: add Grok 4.5 computer use support

### DIFF
--- a/src/client.ts
+++ b/src/client.ts
@@ -12,6 +12,7 @@ import { HyperAgentService } from "./services/agents/hyper-agent";
 import { TeamService } from "./services/team";
 import { ComputerActionService } from "./services/computer-action";
 import { GeminiComputerUseService } from "./services/agents/gemini-computer-use";
+import { GrokComputerUseService } from "./services/agents/grok-computer-use";
 import { WebService } from "./services/web";
 import { SandboxesService } from "./services/sandboxes";
 import { VolumesService } from "./services/volumes";
@@ -67,6 +68,7 @@ export class HyperbrowserClient {
     cua: CuaService;
     hyperAgent: HyperAgentService;
     geminiComputerUse: GeminiComputerUseService;
+    grokComputerUse: GrokComputerUseService;
   };
   public readonly team: TeamService;
   public readonly computerAction: ComputerActionService;
@@ -102,6 +104,7 @@ export class HyperbrowserClient {
       cua: new CuaService(apiKey, baseUrl, timeout),
       hyperAgent: new HyperAgentService(apiKey, baseUrl, timeout),
       geminiComputerUse: new GeminiComputerUseService(apiKey, baseUrl, timeout),
+      grokComputerUse: new GrokComputerUseService(apiKey, baseUrl, timeout),
     };
   }
 }

--- a/src/services/agents/grok-computer-use.ts
+++ b/src/services/agents/grok-computer-use.ts
@@ -15,9 +15,7 @@ export class GrokComputerUseService extends BaseService {
    * Start a new Grok Computer Use task job
    * @param params The parameters for the task job
    */
-  async start(
-    params: StartGrokComputerUseTaskParams
-  ): Promise<StartGrokComputerUseTaskResponse> {
+  async start(params: StartGrokComputerUseTaskParams): Promise<StartGrokComputerUseTaskResponse> {
     try {
       return await this.request<StartGrokComputerUseTaskResponse>("/task/grok-computer-use", {
         method: "POST",
@@ -87,9 +85,7 @@ export class GrokComputerUseService extends BaseService {
    * Start a Grok Computer Use task job and wait for it to complete
    * @param params The parameters for the task job
    */
-  async startAndWait(
-    params: StartGrokComputerUseTaskParams
-  ): Promise<GrokComputerUseTaskResponse> {
+  async startAndWait(params: StartGrokComputerUseTaskParams): Promise<GrokComputerUseTaskResponse> {
     const job = await this.start(params);
     const jobId = job.jobId;
     if (!jobId) {

--- a/src/services/agents/grok-computer-use.ts
+++ b/src/services/agents/grok-computer-use.ts
@@ -1,0 +1,120 @@
+import { HyperbrowserError } from "../../client";
+import { BasicResponse } from "../../types";
+import { POLLING_ATTEMPTS } from "../../types/constants";
+import { sleep } from "../../utils";
+import { BaseService } from "../base";
+import {
+  GrokComputerUseTaskResponse,
+  GrokComputerUseTaskStatusResponse,
+  StartGrokComputerUseTaskParams,
+  StartGrokComputerUseTaskResponse,
+} from "../../types/agents/grok-computer-use";
+
+export class GrokComputerUseService extends BaseService {
+  /**
+   * Start a new Grok Computer Use task job
+   * @param params The parameters for the task job
+   */
+  async start(
+    params: StartGrokComputerUseTaskParams
+  ): Promise<StartGrokComputerUseTaskResponse> {
+    try {
+      return await this.request<StartGrokComputerUseTaskResponse>("/task/grok-computer-use", {
+        method: "POST",
+        body: JSON.stringify(params),
+      });
+    } catch (error) {
+      if (error instanceof HyperbrowserError) {
+        throw error;
+      }
+      throw new HyperbrowserError("Failed to start Grok Computer Use task job", undefined);
+    }
+  }
+
+  /**
+   * Get the status of a Grok Computer Use task job
+   * @param id The ID of the task job to get
+   */
+  async getStatus(id: string): Promise<GrokComputerUseTaskStatusResponse> {
+    try {
+      return await this.request<GrokComputerUseTaskStatusResponse>(
+        `/task/grok-computer-use/${id}/status`
+      );
+    } catch (error) {
+      if (error instanceof HyperbrowserError) {
+        throw error;
+      }
+      throw new HyperbrowserError(
+        `Failed to get Grok Computer Use task job ${id} status`,
+        undefined
+      );
+    }
+  }
+
+  /**
+   * Get the result of a Grok Computer Use task job
+   * @param id The ID of the task job to get
+   */
+  async get(id: string): Promise<GrokComputerUseTaskResponse> {
+    try {
+      return await this.request<GrokComputerUseTaskResponse>(`/task/grok-computer-use/${id}`);
+    } catch (error) {
+      if (error instanceof HyperbrowserError) {
+        throw error;
+      }
+      throw new HyperbrowserError(`Failed to get Grok Computer Use task job ${id}`, undefined);
+    }
+  }
+
+  /**
+   * Stop a Grok Computer Use task job
+   * @param id The ID of the task job to stop
+   */
+  async stop(id: string): Promise<BasicResponse> {
+    try {
+      return await this.request<BasicResponse>(`/task/grok-computer-use/${id}/stop`, {
+        method: "PUT",
+      });
+    } catch (error) {
+      if (error instanceof HyperbrowserError) {
+        throw error;
+      }
+      throw new HyperbrowserError(`Failed to stop Grok Computer Use task job ${id}`, undefined);
+    }
+  }
+
+  /**
+   * Start a Grok Computer Use task job and wait for it to complete
+   * @param params The parameters for the task job
+   */
+  async startAndWait(
+    params: StartGrokComputerUseTaskParams
+  ): Promise<GrokComputerUseTaskResponse> {
+    const job = await this.start(params);
+    const jobId = job.jobId;
+    if (!jobId) {
+      throw new HyperbrowserError(
+        "Failed to start Grok Computer Use task job, could not get job ID"
+      );
+    }
+
+    let failures = 0;
+    while (true) {
+      try {
+        const { status } = await this.getStatus(jobId);
+        if (status === "completed" || status === "failed" || status === "stopped") {
+          return await this.get(jobId);
+        }
+        failures = 0;
+      } catch (error) {
+        failures++;
+        if (failures >= POLLING_ATTEMPTS) {
+          throw new HyperbrowserError(
+            `Failed to poll Grok Computer Use task job ${jobId} after ${POLLING_ATTEMPTS} attempts: ${error}`
+          );
+        }
+      }
+      await sleep(2000);
+    }
+  }
+}

--- a/src/types/agents/grok-computer-use.ts
+++ b/src/types/agents/grok-computer-use.ts
@@ -1,0 +1,61 @@
+import { GrokComputerUseLlm, GrokReasoningEffort, GrokComputerUseTaskStatus } from "../constants";
+import { CreateSessionParams } from "../session";
+
+export interface GrokComputerUseApiKeys {
+  xai?: string;
+}
+
+export interface StartGrokComputerUseTaskParams {
+  task: string;
+  llm?: GrokComputerUseLlm;
+  reasoningEffort?: GrokReasoningEffort;
+  sessionId?: string;
+  maxFailures?: number;
+  maxSteps?: number;
+  keepBrowserOpen?: boolean;
+  sessionOptions?: CreateSessionParams;
+  useCustomApiKeys?: boolean;
+  apiKeys?: GrokComputerUseApiKeys;
+  useComputerAction?: boolean;
+}
+
+export interface StartGrokComputerUseTaskResponse {
+  jobId: string;
+  liveUrl: string | null;
+}
+
+export interface GrokComputerUseTaskStatusResponse {
+  status: GrokComputerUseTaskStatus;
+}
+
+export interface GrokComputerUseStepResponse {
+  created_at?: string | null;
+  completed_at?: string | null;
+  output_text?: string | null;
+  error?: string | null;
+  incomplete_details?: any;
+  model?: string | null;
+  output?: any[];
+  reasoning?: any;
+  status?: string | null;
+}
+
+export interface GrokComputerUseTaskData {
+  steps: GrokComputerUseStepResponse[];
+  finalResult: string | null;
+}
+
+export interface GrokComputerUseTaskMetadata {
+  inputTokens?: number | null;
+  outputTokens?: number | null;
+  numTaskStepsCompleted?: number | null;
+}
+
+export interface GrokComputerUseTaskResponse {
+  jobId: string;
+  status: GrokComputerUseTaskStatus;
+  metadata?: GrokComputerUseTaskMetadata | null;
+  data?: GrokComputerUseTaskData | null;
+  error?: string | null;
+  liveUrl: string | null;
+}

--- a/src/types/constants.ts
+++ b/src/types/constants.ts
@@ -22,12 +22,7 @@ export type GeminiComputerUseTaskStatus =
   | "completed"
   | "failed"
   | "stopped";
-export type GrokComputerUseTaskStatus =
-  | "pending"
-  | "running"
-  | "completed"
-  | "failed"
-  | "stopped";
+export type GrokComputerUseTaskStatus = "pending" | "running" | "completed" | "failed" | "stopped";
 export type ScrapePageStatus = "completed" | "failed" | "pending" | "running";
 export type CrawlPageStatus = "completed" | "failed";
 export type ScrapeWaitUntil = "load" | "domcontentloaded" | "networkidle";

--- a/src/types/constants.ts
+++ b/src/types/constants.ts
@@ -22,6 +22,12 @@ export type GeminiComputerUseTaskStatus =
   | "completed"
   | "failed"
   | "stopped";
+export type GrokComputerUseTaskStatus =
+  | "pending"
+  | "running"
+  | "completed"
+  | "failed"
+  | "stopped";
 export type ScrapePageStatus = "completed" | "failed" | "pending" | "running";
 export type CrawlPageStatus = "completed" | "failed";
 export type ScrapeWaitUntil = "load" | "domcontentloaded" | "networkidle";
@@ -94,6 +100,10 @@ export type GeminiComputerUseLlm =
   | "gemini-3.5-flash"
   | "gemini-3-flash-preview"
   | "gemini-2.5-computer-use-preview-10-2025";
+
+export type GrokComputerUseLlm = "grok-4.5";
+
+export type GrokReasoningEffort = "low" | "medium" | "high";
 
 export type SessionRegion =
   | "us-central"

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -92,6 +92,16 @@ export {
   GeminiComputerUseTaskMetadata,
 } from "./agents/gemini-computer-use";
 export {
+  StartGrokComputerUseTaskParams,
+  StartGrokComputerUseTaskResponse,
+  GrokComputerUseTaskStatusResponse,
+  GrokComputerUseTaskResponse,
+  GrokComputerUseTaskData,
+  GrokComputerUseStepResponse,
+  GrokComputerUseApiKeys,
+  GrokComputerUseTaskMetadata,
+} from "./agents/grok-computer-use";
+export {
   BasicResponse,
   BrowserMemorySize,
   SessionStatus,
@@ -210,6 +220,8 @@ export {
   ClaudeComputerUseLlm,
   CuaLlm,
   GeminiComputerUseLlm,
+  GrokComputerUseLlm,
+  GrokReasoningEffort,
   ScrapeScreenshotFormat,
   ScrapeJobStatus,
   CrawlJobStatus,
@@ -229,6 +241,7 @@ export {
   ClaudeComputerUseTaskStatus,
   CuaTaskStatus,
   GeminiComputerUseTaskStatus,
+  GrokComputerUseTaskStatus,
   SessionEventLogType,
   SessionRegion,
   BrowserUseVersion,


### PR DESCRIPTION
## Summary
Add SDK support for the new Grok 4.5 computer-use agent (`grokcu`) introduced in `browserctrl#1212`.

## Changes
- Add `GrokComputerUseLlm` (`grok-4.5`) and `GrokReasoningEffort` (`low`/`medium`/`high`) types.
- Add `GrokComputerUseApiKeys`, `StartGrokComputerUseTaskParams`, and response types (`GrokComputerUseTaskResponse`, `GrokComputerUseTaskData`, etc.).
- Add `GrokComputerUseService` (`client.agents.grokComputerUse`) wiring to `/task/grok-computer-use` endpoints.
- Export new types from `src/types/index.ts` and `src/client.ts`.

## Validation
- `yarn lint`
- `yarn build`

<!-- Supports browserctrl#1212 -->

Link to Devin session: https://app.devin.ai/sessions/5a70ddea4e9f4f0cb35baef951897bed
Requested by: @shrisukhani

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Additive SDK surface following the existing Gemini computer-use service pattern; no changes to auth, sessions, or core request handling.
> 
> **Overview**
> Adds **Grok computer-use** to the Hyperbrowser SDK so callers can start and manage Grok 4.5 browser automation jobs through the same agent pattern as the other computer-use integrations.
> 
> `HyperbrowserClient.agents` gains **`grokComputerUse`**, backed by a new service that talks to `/task/grok-computer-use` with **`start`**, **`getStatus`**, **`get`**, **`stop`**, and **`startAndWait`** (poll until completed/failed/stopped). New TypeScript types cover task params (including optional **`grok-4.5`**, **`reasoningEffort`**, session options, and optional xAI API keys), job responses, steps, and metadata; **`GrokComputerUseTaskStatus`**, **`GrokComputerUseLlm`**, and **`GrokReasoningEffort`** are added to shared constants and re-exported from the public types surface.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit fc0e6f5bb0801154c38dadc072d0f3bf442e6baf. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->