### PR TITLE
feat: add Gemini 3.6 Flash and 3.5 Flash Lite to Gemini CUA

### DIFF
--- a/src/types/constants.ts
+++ b/src/types/constants.ts
@@ -92,6 +92,8 @@ export type HyperAgentLlm =
   | "gemini-3-flash-preview";
 
 export type GeminiComputerUseLlm =
+  | "gemini-3.6-flash"
+  | "gemini-3.5-flash-lite"
   | "gemini-3.5-flash"
   | "gemini-3-flash-preview"
   | "gemini-2.5-computer-use-preview-10-2025";

--- a/src/types/constants.ts
+++ b/src/types/constants.ts
@@ -93,7 +93,6 @@ export type HyperAgentLlm =
 
 export type GeminiComputerUseLlm =
   | "gemini-3.6-flash"
-  | "gemini-3.5-flash-lite"
   | "gemini-3.5-flash"
   | "gemini-3-flash-preview"
   | "gemini-2.5-computer-use-preview-10-2025";

--- a/src/types/constants.ts
+++ b/src/types/constants.ts
@@ -94,6 +94,7 @@ export type HyperAgentLlm =
 export type GeminiComputerUseLlm =
   | "gemini-3.6-flash"
   | "gemini-3.5-flash"
+  | "gemini-3.5-flash-lite"
   | "gemini-3-flash-preview"
   | "gemini-2.5-computer-use-preview-10-2025";
 


### PR DESCRIPTION
## Summary
Adds `gemini-3.6-flash` and `gemini-3.5-flash-lite` to the `GeminiComputerUseLlm` type.

## Changes
- `src/types/constants.ts`: expanded `GeminiComputerUseLlm`

## Validation
- `COREPACK_ENABLE_PROJECT_SPEC=0 corepack yarn build` ✅
- `COREPACK_ENABLE_PROJECT_SPEC=0 corepack yarn lint` ✅


Link to Devin session: https://app.devin.ai/sessions/ca22b203b89844a0a119b73600d0efe7
Requested by: @shrisukhani

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Narrow type-definition change with no auth, data, or execution-path updates; worst case is callers selecting a model the API may not support.
> 
> **Overview**
> Updates the **`GeminiComputerUseLlm`** union in `constants.ts` so Gemini computer-use tasks can be typed with two additional model IDs: **`gemini-3.6-flash`** and **`gemini-3.5-flash-lite`**.
> 
> This is a compile-time-only change to the SDK’s allowed `llm` values for Gemini CUA; no runtime logic or service code is modified in this diff.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 4f1f688884277f4f4d275fd2874e73c71e01fb32. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->