### PR TITLE
chore: bump version to 0.91.5

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hyperbrowser/sdk",
-  "version": "0.91.4",
+  "version": "0.91.5",
   "description": "Node SDK for Hyperbrowser API",
   "author": "",
   "repository": {


### PR DESCRIPTION
## Summary
Bumps the Node SDK patch version to prepare for release after adding the new Gemini CUA model options.

## Changes
- `package.json`: version `0.91.4` → `0.91.5`

## Validation
- `COREPACK_ENABLE_PROJECT_SPEC=0 corepack yarn build` ✅
- `COREPACK_ENABLE_PROJECT_SPEC=0 corepack yarn lint` ✅


Link to Devin session: https://app.devin.ai/sessions/ca22b203b89844a0a119b73600d0efe7
Requested by: @shrisukhani

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Single metadata field change with no runtime or behavioral impact.
> 
> **Overview**
> Bumps `@hyperbrowser/sdk` from **0.91.4** to **0.91.5** in `package.json` only—a patch release version increment with no code or API changes in this diff.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 63cc6e899bc504e0259a23137b4eef13b87185df. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->