### PR TITLE
fix github workflow

### DIFF
--- a/.github/workflows/publish-npm.yml
+++ b/.github/workflows/publish-npm.yml
@@ -33,7 +33,7 @@ jobs:
           corepack prepare yarn@1.22.22 --activate
 
       - name: Upgrade npm
-        run: npm install -g npm@latest
+        run: npm install -g npm@11.18.0
 
       - name: Show tool versions
         run: |

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hyperbrowser/sdk",
-  "version": "0.91.5",
+  "version": "0.91.6",
   "description": "Node SDK for Hyperbrowser API",
   "author": "",
   "repository": {


### PR DESCRIPTION
## Summary
<!-- 1-2 sentences: what changed and why. -->

## Changes
<!-- Bullet list of the concrete changes. Keep it short. -->
- 
- 

## Validation
<!-- Commands you ran. Mention any manual testing. -->
- `yarn lint`
- `yarn build`

<!-- Closes #123 -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> CI tooling pin and version bump only; no runtime SDK logic changes.
> 
> **Overview**
> **Pins npm in the npm publish workflow** so release jobs no longer run `npm install -g npm@latest`, using **npm@11.18.0** instead for more predictable publish behavior.
> 
> **Bumps** `@hyperbrowser/sdk` from **0.91.5** to **0.91.6** in `package.json` (aligned with the release tag check in the same workflow).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 846b1b8384539673266e2e43269e2b71dc64c0cb. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->