### PR TITLE
add browser network policy

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hyperbrowser/sdk",
-  "version": "0.91.7",
+  "version": "0.91.8",
   "description": "Node SDK for Hyperbrowser API",
   "author": "",
   "repository": {

--- a/src/types/session.ts
+++ b/src/types/session.ts
@@ -35,6 +35,9 @@ export interface SessionLaunchState {
   enableWebRecording?: boolean;
   enableVideoWebRecording?: boolean;
   enableLogCapture?: boolean;
+  allowInternetAccess?: boolean;
+  allowOut?: string[];
+  denyOut?: string[];
   acceptCookies?: boolean;
   solverType?: CaptchaSolverType;
   profile?: SessionProfile;
@@ -184,6 +187,9 @@ export interface CreateSessionParams {
   enableWebRecording?: boolean;
   enableVideoWebRecording?: boolean;
   enableLogCapture?: boolean;
+  allowInternetAccess?: boolean;
+  allowOut?: string[];
+  denyOut?: string[];
   profile?: CreateSessionProfile;
   extensionIds?: Array<string>;
   staticIpId?: string;


### PR DESCRIPTION
## Summary
<!-- 1-2 sentences: what changed and why. -->

## Changes
<!-- Bullet list of the concrete changes. Keep it short. -->
- 
- 

## Validation
<!-- Commands you ran. Mention any manual testing. -->
- `yarn lint`
- `yarn build`

<!-- Closes #123 -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Type-only additions and a patch version bump with no runtime or security logic changes in this repo.
> 
> **Overview**
> Exposes **browser network policy** options on session create and launch-state types so SDK consumers can configure outbound traffic when starting or inspecting sessions.
> 
> **`CreateSessionParams`** and **`SessionLaunchState`** now include optional `allowInternetAccess` (boolean), `allowOut` (string allowlist), and `denyOut` (string denylist). Package version is bumped to **0.91.8**; there is no new client logic beyond typing—these fields pass through to the API like other session flags.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 1afaa98a10712a3e730e9023fca21402c55741e9. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->