### PR TITLE
Add sandboxes.deleteImage for DELETE /images/:key

### DIFF
--- a/src/services/sandboxes.ts
+++ b/src/services/sandboxes.ts
@@ -28,6 +28,7 @@ import {
   SandboxNetworkPolicyPatch,
   SandboxNetworkUpdateResult,
   SandboxProcessResult,
+  SandboxImageDeleteResult,
   SandboxSnapshotDeleteResult,
   SandboxSnapshotListParams,
   SandboxSnapshotListResponse,
@@ -511,6 +512,20 @@ export class SandboxesService extends BaseService {
         throw error;
       }
       throw new HyperbrowserError("Failed to list sandboxes", undefined);
+    }
+  }
+
+  async deleteImage(image: string): Promise<SandboxImageDeleteResult> {
+    try {
+      return await this.request<SandboxImageDeleteResult>(
+        `/images/${encodeURIComponent(image)}`,
+        { method: "DELETE" }
+      );
+    } catch (error) {
+      if (error instanceof HyperbrowserError) {
+        throw error;
+      }
+      throw new HyperbrowserError(`Failed to delete image ${image}`);
     }
   }
 

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -161,6 +161,7 @@ export {
   SandboxSnapshotListParams,
   SandboxSnapshotListResponse,
   SandboxSnapshotDeleteResult,
+  SandboxImageDeleteResult,
   SandboxImageBuildStatus,
   SandboxImageBuildUpload,
   SandboxImageBuild,

--- a/src/types/sandbox.ts
+++ b/src/types/sandbox.ts
@@ -183,6 +183,9 @@ export interface SandboxSnapshotDeleteResult {
 
 export interface SandboxImageDeleteResult {
   deleted: boolean;
+  id?: string;
+  imageName?: string;
+  uploaded?: boolean;
 }
 
 export type SandboxImageBuildStatus =

--- a/src/types/sandbox.ts
+++ b/src/types/sandbox.ts
@@ -181,6 +181,10 @@ export interface SandboxSnapshotDeleteResult {
   deleted: boolean;
 }
 
+export interface SandboxImageDeleteResult {
+  deleted: boolean;
+}
+
 export type SandboxImageBuildStatus =
   | "awaiting_upload"
   | "upload_verified"

--- a/tests/sandbox/e2e/list-contract.test.ts
+++ b/tests/sandbox/e2e/list-contract.test.ts
@@ -101,6 +101,18 @@ describe("sandbox control list contract", () => {
     expect(response).toEqual(payload);
   });
 
+  test("deleteImage sends DELETE /images/:key", async () => {
+    const service = new SandboxesService("test-key", "https://api.example.com", 30_000);
+    const requestSpy = vi
+      .spyOn(service as any, "request")
+      .mockResolvedValue({ deleted: true });
+
+    const response = await service.deleteImage("custom_node");
+
+    expect(requestSpy).toHaveBeenCalledWith("/images/custom_node", { method: "DELETE" });
+    expect(response).toEqual({ deleted: true });
+  });
+
   test("listSnapshots returns the wrapped snapshot response from the control API", async () => {
     const service = new SandboxesService("test-key", "https://api.example.com", 30_000);
     const payload = {

--- a/tests/sandbox/e2e/list-contract.test.ts
+++ b/tests/sandbox/e2e/list-contract.test.ts
@@ -105,12 +105,22 @@ describe("sandbox control list contract", () => {
     const service = new SandboxesService("test-key", "https://api.example.com", 30_000);
     const requestSpy = vi
       .spyOn(service as any, "request")
-      .mockResolvedValue({ deleted: true });
+      .mockResolvedValue({
+        deleted: true,
+        id: "img_123",
+        imageName: "custom_node",
+        uploaded: true,
+      });
 
     const response = await service.deleteImage("custom_node");
 
     expect(requestSpy).toHaveBeenCalledWith("/images/custom_node", { method: "DELETE" });
-    expect(response).toEqual({ deleted: true });
+    expect(response).toEqual({
+      deleted: true,
+      id: "img_123",
+      imageName: "custom_node",
+      uploaded: true,
+    });
   });
 
   test("listSnapshots returns the wrapped snapshot response from the control API", async () => {


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
Adds `sandboxes.deleteImage()` for `DELETE /images/:key`.

## Changes
- `SandboxesService.deleteImage(image)` calls `DELETE /images/:key`
- `SandboxImageDeleteResult` includes optional `id`, `imageName`, and `uploaded` from the server

## Validation
- `yarn test tests/sandbox/e2e/list-contract.test.ts` — pass
- `yarn build` — pass

Companion: [browserctrl#1303](https://github.com/hyperbrowserai/browserctrl/pull/1303)
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-ebee49d4-a788-4959-951b-beb871884e4e?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-ebee49d4-a788-4959-951b-beb871884e4e&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

