### PR TITLE
feat: add Gemini 3.7 Flash to Gemini CUA and HyperAgent

### DIFF
--- a/src/types/constants.ts
+++ b/src/types/constants.ts
@@ -90,9 +90,11 @@ export type HyperAgentLlm =
   | "claude-sonnet-4-5"
   | "claude-sonnet-4-6"
   | "gemini-2.5-flash"
+  | "gemini-3.7-flash"
   | "gemini-3-flash-preview";
 
 export type GeminiComputerUseLlm =
+  | "gemini-3.7-flash"
   | "gemini-3.6-flash"
   | "gemini-3.5-flash"
   | "gemini-3.5-flash-lite"


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
Adds `gemini-3.7-flash` to the Gemini Computer Use and HyperAgent LLM types so the Node SDK matches [browserctrl#1310](https://github.com/hyperbrowserai/browserctrl/pull/1310).

## Changes
- `src/types/constants.ts`: added `gemini-3.7-flash` to `GeminiComputerUseLlm` and `HyperAgentLlm`

## Validation
- `yarn lint` — passed
- `yarn build` (`tsc`) — passed
- `yarn test` has no local unit files (suite is e2e/integration only and needs `HYPERBROWSER_API_KEY`)

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-ef3c4462-48ec-4ead-bcfe-4f34b1ec7650?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-ef3c4462-48ec-4ead-bcfe-4f34b1ec7650&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

