### PR TITLE
Add volumes.delete for DELETE /volume/:key

### DIFF
--- a/README.md
+++ b/README.md
@@ -274,6 +274,7 @@ const sandbox = await client.sandboxes.create({
 });
 
 await sandbox.stop();
+await client.volumes.delete(sameVolume.id);
 ```
 
 List sandboxes with time-range and search filters:

--- a/src/services/volumes.ts
+++ b/src/services/volumes.ts
@@ -60,6 +60,8 @@ export class VolumesService extends BaseService {
 
   /**
    * Delete a sandbox volume by id or name.
+   * Name lookup is case-insensitive. Multiple volumes that share a name
+   * return 409 and require an id. Active mounts also return 409.
    */
   async delete(key: string): Promise<VolumeDeleteResult> {
     try {

--- a/src/services/volumes.ts
+++ b/src/services/volumes.ts
@@ -1,5 +1,11 @@
 import { HyperbrowserError } from "../client";
-import { CreateVolumeParams, Volume, VolumeListParams, VolumeListResponse } from "../types/volume";
+import {
+  CreateVolumeParams,
+  Volume,
+  VolumeDeleteResult,
+  VolumeListParams,
+  VolumeListResponse,
+} from "../types/volume";
 import { BaseService } from "./base";
 
 export class VolumesService extends BaseService {
@@ -49,6 +55,23 @@ export class VolumesService extends BaseService {
         throw error;
       }
       throw new HyperbrowserError(`Failed to get volume ${id}`, undefined);
+    }
+  }
+
+  /**
+   * Delete a sandbox volume by id or name.
+   */
+  async delete(key: string): Promise<VolumeDeleteResult> {
+    try {
+      return await this.request<VolumeDeleteResult>(
+        `/volume/${encodeURIComponent(key)}`,
+        { method: "DELETE" }
+      );
+    } catch (error) {
+      if (error instanceof HyperbrowserError) {
+        throw error;
+      }
+      throw new HyperbrowserError(`Failed to delete volume ${key}`, undefined);
     }
   }
 }

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -214,7 +214,13 @@ export {
   SandboxTerminalKillParams,
   SandboxTerminalEvent,
 } from "./sandbox";
-export { CreateVolumeParams, Volume, VolumeListParams, VolumeListResponse } from "./volume";
+export {
+  CreateVolumeParams,
+  Volume,
+  VolumeListParams,
+  VolumeListResponse,
+  VolumeDeleteResult,
+} from "./volume";
 export {
   CreateProfileParams,
   ForkProfileParams,

--- a/src/types/volume.ts
+++ b/src/types/volume.ts
@@ -21,3 +21,9 @@ export interface VolumeListResponse {
   page?: number;
   perPage?: number;
 }
+
+export interface VolumeDeleteResult {
+  deleted: boolean;
+  id?: string;
+  name?: string;
+}

--- a/tests/sandbox/e2e/volumes-contract.test.ts
+++ b/tests/sandbox/e2e/volumes-contract.test.ts
@@ -68,4 +68,22 @@ describe("volume control contract", () => {
     expect(requestSpy).toHaveBeenCalledWith("/volume/2d6f01cf-c5d7-4c61-ae9e-0264f1c8063d");
     expect(response).toEqual(payload);
   });
+
+  test("delete forwards the volume key and returns the deleted revision", async () => {
+    const service = new VolumesService("test-key", "https://api.example.com", 30_000);
+    const payload = {
+      deleted: true,
+      id: "2d6f01cf-c5d7-4c61-ae9e-0264f1c8063d",
+      name: "project-cache",
+    };
+
+    const requestSpy = vi.spyOn(service as any, "request").mockResolvedValue(payload);
+
+    const response = await service.delete("project-cache");
+
+    expect(requestSpy).toHaveBeenCalledWith("/volume/project-cache", {
+      method: "DELETE",
+    });
+    expect(response).toEqual(payload);
+  });
 });


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
Adds `volumes.delete()` for `DELETE /volume/:key`.

## Changes
- `VolumesService.delete(key)` calls `DELETE /volume/:key`
- `VolumeDeleteResult` includes `deleted`, `id`, and `name` from the server
- Documents 409s for ambiguous names and active mounts

## Validation
- `yarn test tests/sandbox/e2e/volumes-contract.test.ts` — pass
- `yarn build` — pass

Companion: [browserctrl#1311](https://github.com/hyperbrowserai/browserctrl/pull/1311)
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-b624b5b9-60c2-4f9a-8f41-76712aea998c?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-b624b5b9-60c2-4f9a-8f41-76712aea998c&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

