### PR TITLE
add custom baseurl for cua

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hyperbrowser/sdk",
-  "version": "0.92.2",
+  "version": "0.92.3",
   "description": "Node SDK for Hyperbrowser API",
   "author": "",
   "repository": {

--- a/src/services/sandboxes.ts
+++ b/src/services/sandboxes.ts
@@ -517,10 +517,9 @@ export class SandboxesService extends BaseService {
 
   async deleteImage(image: string): Promise<SandboxImageDeleteResult> {
     try {
-      return await this.request<SandboxImageDeleteResult>(
-        `/images/${encodeURIComponent(image)}`,
-        { method: "DELETE" }
-      );
+      return await this.request<SandboxImageDeleteResult>(`/images/${encodeURIComponent(image)}`, {
+        method: "DELETE",
+      });
     } catch (error) {
       if (error instanceof HyperbrowserError) {
         throw error;

--- a/src/types/agents/cua.ts
+++ b/src/types/agents/cua.ts
@@ -5,6 +5,10 @@ export interface CuaApiKeys {
   openai?: string;
 }
 
+export interface CuaBaseUrls {
+  openai?: string;
+}
+
 export interface StartCuaTaskParams {
   task: string;
   llm?: CuaLlm;
@@ -15,6 +19,7 @@ export interface StartCuaTaskParams {
   sessionOptions?: CreateSessionParams;
   useCustomApiKeys?: boolean;
   apiKeys?: CuaApiKeys;
+  baseUrls?: CuaBaseUrls;
   useComputerAction?: boolean;
 }
 

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -65,6 +65,7 @@ export {
   CuaTaskData,
   CuaStepResponse,
   CuaApiKeys,
+  CuaBaseUrls,
   CuaTaskMetadata,
 } from "./agents/cua";
 export {

--- a/tests/integration/client-http.test.ts
+++ b/tests/integration/client-http.test.ts
@@ -55,6 +55,11 @@ const startServer = async (): Promise<TestServer> => {
       return;
     }
 
+    if (request.method === "POST" && request.url === "/api/task/cua") {
+      sendJson(response, 200, { jobId: "cua_job_123", liveUrl: null });
+      return;
+    }
+
     if (request.method === "POST" && request.url === "/api/session") {
       sendJson(response, 200, {
         id: "52dd29fb-75a2-43f9-9831-8ff377fedb0a",
@@ -213,6 +218,40 @@ describe("client HTTP integration", () => {
         apiKey: "test-api-key",
         contentType: "application/json",
         body: undefined,
+      },
+    ]);
+  });
+
+  test("OpenAI CUA forwards a custom provider base URL", async () => {
+    const server = await startServer();
+    servers.push(server);
+    const client = new HyperbrowserClient({
+      apiKey: "test-api-key",
+      baseUrl: server.baseUrl,
+    });
+
+    const started = await client.agents.cua.start({
+      task: "Complete the task",
+      llm: "gpt-5.4-mini",
+      useCustomApiKeys: true,
+      apiKeys: { openai: "openai-key" },
+      baseUrls: { openai: "https://example.openai.azure.com/openai/v1/" },
+    });
+
+    expect(started).toEqual({ jobId: "cua_job_123", liveUrl: null });
+    expect(server.requests).toEqual([
+      {
+        method: "POST",
+        url: "/api/task/cua",
+        apiKey: "test-api-key",
+        contentType: "application/json",
+        body: {
+          task: "Complete the task",
+          llm: "gpt-5.4-mini",
+          useCustomApiKeys: true,
+          apiKeys: { openai: "openai-key" },
+          baseUrls: { openai: "https://example.openai.azure.com/openai/v1/" },
+        },
       },
     ]);
   });


### PR DESCRIPTION
## Summary
<!-- 1-2 sentences: what changed and why. -->

## Changes
<!-- Bullet list of the concrete changes. Keep it short. -->
- 
- 

## Validation
<!-- Commands you ran. Mention any manual testing. -->
- `yarn lint`
- `yarn build`

<!-- Closes #123 -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Additive optional typing and request payload field with no changes to auth or core request handling beyond forwarding the new property.
> 
> **Overview**
> Adds optional **`baseUrls`** on CUA task start so callers can point the OpenAI provider at a custom endpoint (e.g. Azure OpenAI) alongside existing custom API keys.
> 
> Introduces **`CuaBaseUrls`** with an optional `openai` field on **`StartCuaTaskParams`**, exports it from the public types package, and bumps the SDK to **0.92.3**. An integration test asserts **`POST /api/task/cua`** includes `baseUrls` in the request body when set.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 8ca4fd1675876c9f1805ca501e53c851ef543562. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->